### PR TITLE
Don't create a new error when http requests fail.

### DIFF
--- a/pkg/connector/pagination.go
+++ b/pkg/connector/pagination.go
@@ -51,7 +51,7 @@ func convertPageToken(token string) (uint, error) {
 func prepareNextToken(page uint, pageTotal int, total uint) string {
 	var token string
 
-	next := page + uint(pageTotal)
+	next := page + uint(pageTotal) // #nosec G115
 	if next < total+1 {
 		token = strconv.FormatUint(uint64(next), 10)
 	}

--- a/pkg/databricks/client.go
+++ b/pkg/databricks/client.go
@@ -595,7 +595,7 @@ func (c *Client) doRequest(ctx context.Context, urlAddress *url.URL, method stri
 	c.auth.Apply(req)
 	resp, err := c.httpClient.Do(req, WithJSONResponse(&response))
 	if err != nil {
-		return fmt.Errorf("databricks-connector: error: %s", err.Error())
+		return err
 	}
 
 	defer resp.Body.Close()


### PR DESCRIPTION
This fixes an issue where we failed to retry rate limit errors.