### PR TITLE
Generate grant expansion entitlement IDs without using resource cache.

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -50,9 +50,6 @@ linters-settings:
   tenv:
     all: true
 
-  varcheck:
-    exported-fields: false # this appears to improperly detect exported variables as unused when they are used from a package with the same name
-
 
 linters:
   disable-all: true

--- a/pkg/connector/connector.go
+++ b/pkg/connector/connector.go
@@ -12,20 +12,19 @@ import (
 )
 
 type Databricks struct {
-	client        *databricks.Client
-	workspaces    []string
-	resourceCache *ResourceCache
+	client     *databricks.Client
+	workspaces []string
 }
 
 // ResourceSyncers returns a ResourceSyncer for each resource type that should be synced from the upstream service.
 func (d *Databricks) ResourceSyncers(ctx context.Context) []connectorbuilder.ResourceSyncer {
 	return []connectorbuilder.ResourceSyncer{
-		newAccountBuilder(d.client, d.resourceCache),
-		newGroupBuilder(d.client, d.resourceCache),
-		newServicePrincipalBuilder(d.client, d.resourceCache),
-		newUserBuilder(d.client, d.resourceCache),
-		newWorkspaceBuilder(d.client, d.resourceCache, d.workspaces),
-		newRoleBuilder(d.client, d.resourceCache),
+		newAccountBuilder(d.client),
+		newGroupBuilder(d.client),
+		newServicePrincipalBuilder(d.client),
+		newUserBuilder(d.client),
+		newWorkspaceBuilder(d.client, d.workspaces),
+		newRoleBuilder(d.client),
 	}
 }
 
@@ -117,8 +116,7 @@ func New(
 	}
 
 	return &Databricks{
-		client:        client,
-		workspaces:    workspaces,
-		resourceCache: NewResourceCache(client),
+		client:     client,
+		workspaces: workspaces,
 	}, nil
 }

--- a/pkg/connector/users.go
+++ b/pkg/connector/users.go
@@ -12,9 +12,8 @@ import (
 )
 
 type userBuilder struct {
-	client        *databricks.Client
-	resourceType  *v2.ResourceType
-	resourceCache *ResourceCache
+	client       *databricks.Client
+	resourceType *v2.ResourceType
 }
 
 func (u *userBuilder) ResourceType(ctx context.Context) *v2.ResourceType {
@@ -77,8 +76,6 @@ func (u *userBuilder) userResource(ctx context.Context, user *databricks.User, p
 	if err != nil {
 		return nil, err
 	}
-
-	u.resourceCache.Set(user.ID, resource)
 
 	return resource, nil
 }
@@ -159,10 +156,9 @@ func (u *userBuilder) Grants(
 	return nil, "", nil, nil
 }
 
-func newUserBuilder(client *databricks.Client, resourceCache *ResourceCache) *userBuilder {
+func newUserBuilder(client *databricks.Client) *userBuilder {
 	return &userBuilder{
-		client:        client,
-		resourceType:  userResourceType,
-		resourceCache: resourceCache,
+		client:       client,
+		resourceType: userResourceType,
 	}
 }


### PR DESCRIPTION
This fixes an error with Azure Databricks and improves performance.