### PR TITLE
[BB-1883] Remove deprecated auth methods (token and PAT)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -20,7 +20,7 @@ endif
 build: $(GENERATED_CONF)
 	go build ${BUILD_TAGS} -o ${OUTPUT_PATH} ./cmd/baton-databricks
     
-$(GENERATED_CONF): pkg/config/schema.go go.mod
+$(GENERATED_CONF): pkg/config/config.go go.mod
 	@echo "Generating $(GENERATED_CONF)..."
 	go generate ./pkg/config
     

--- a/pkg/config/conf.gen.go
+++ b/pkg/config/conf.gen.go
@@ -11,8 +11,10 @@ type Databricks struct {
 	Hostname string `mapstructure:"hostname"`
 	Password string `mapstructure:"password"`
 	WorkspaceTokens []string `mapstructure:"workspace-tokens"`
+	PersonalAccessToken string `mapstructure:"personal-access-token"`
 	Username string `mapstructure:"username"`
 	Workspaces []string `mapstructure:"workspaces"`
+	WorkspaceId string `mapstructure:"workspace-id"`
 }
 
 func (c *Databricks) findFieldByTag(tagValue string) (any, bool) {

--- a/pkg/config/conf.gen.go
+++ b/pkg/config/conf.gen.go
@@ -9,12 +9,6 @@ type Databricks struct {
 	DatabricksClientId string `mapstructure:"databricks-client-id"`
 	DatabricksClientSecret string `mapstructure:"databricks-client-secret"`
 	Hostname string `mapstructure:"hostname"`
-	Password string `mapstructure:"password"`
-	WorkspaceTokens []string `mapstructure:"workspace-tokens"`
-	PersonalAccessToken string `mapstructure:"personal-access-token"`
-	Username string `mapstructure:"username"`
-	Workspaces []string `mapstructure:"workspaces"`
-	WorkspaceId string `mapstructure:"workspace-id"`
 }
 
 func (c *Databricks) findFieldByTag(tagValue string) (any, bool) {

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -1,76 +1,40 @@
 package config
 
 import (
-	"context"
-	"fmt"
-
 	"github.com/conductorone/baton-sdk/pkg/field"
 )
 
 var (
-	AccountHostnameField = field.StringField(
-		"account-hostname",
-		field.WithDefaultValue("accounts.cloud.databricks.com"),
-		field.WithDescription("The hostname used to connect to the Databricks account API. If not set, it will be calculated from the hostname field."),
-		field.WithDisplayName("Account Hostname (optional)"),
-	)
 	AccountIdField = field.StringField(
 		"account-id",
 		field.WithDescription("The Databricks account ID used to connect to the Databricks Account and Workspace API"),
 		field.WithRequired(true),
 		field.WithDisplayName("Account ID"),
 	)
-	HostnameField = field.StringField(
-		"hostname",
-		field.WithDescription("The Databricks hostname used to connect to the Databricks API"),
-		field.WithDefaultValue("cloud.databricks.com"),
-		field.WithDisplayName("Hostname (optional)"),
-	)
 	DatabricksClientIdField = field.StringField(
 		"databricks-client-id",
 		field.WithDescription("The Databricks service principal's client ID used to connect to the Databricks Account and Workspace API"),
 		field.WithDisplayName("OAuth2 Client ID"),
+		field.WithRequired(true),
 	)
 	DatabricksClientSecretField = field.StringField(
 		"databricks-client-secret",
 		field.WithDescription("The Databricks service principal's client secret used to connect to the Databricks Account and Workspace API"),
 		field.WithIsSecret(true),
+		field.WithRequired(true),
 		field.WithDisplayName("OAuth2 Client Secret"),
 	)
-	UsernameField = field.StringField(
-		"username",
-		field.WithDescription("The Databricks username used to connect to the Databricks API"),
-		field.WithDisplayName("Username"),
+	AccountHostnameField = field.StringField(
+		"account-hostname",
+		field.WithDefaultValue("accounts.cloud.databricks.com"),
+		field.WithDescription("The hostname used to connect to the Databricks account API. If not set, it will be calculated from the hostname field."),
+		field.WithDisplayName("Account Hostname"),
 	)
-	PasswordField = field.StringField(
-		"password",
-		field.WithDescription("The Databricks password used to connect to the Databricks API"),
-		field.WithIsSecret(true),
-		field.WithDisplayName("Password"),
-	)
-	WorkspaceIDField = field.StringField(
-		"workspace-id",
-		field.WithDescription("The Databricks workspace ID used to connect to the Databricks Workspace API"),
-		field.WithDisplayName("Workspace ID"),
-	)
-	WorkspacesField = field.StringSliceField(
-		"workspaces",
-		field.WithDescription("Limit syncing to the specified workspaces"),
-		field.WithDisplayName("Workspaces"),
-		field.WithExportTarget(field.ExportTargetCLIOnly),
-	)
-	PersonalAccessTokenField = field.StringField(
-		"personal-access-token",
-		field.WithDescription("The Databricks personal access token used to connect to the Databricks Workspace API"),
-		field.WithIsSecret(true),
-		field.WithDisplayName("Personal access token"),
-	)
-	TokensField = field.StringSliceField(
-		"workspace-tokens",
-		field.WithDescription("The Databricks access tokens scoped to specific workspaces used to connect to the Databricks Workspace API"),
-		field.WithIsSecret(true),
-		field.WithDisplayName("Personal access tokens"),
-		field.WithExportTarget(field.ExportTargetCLIOnly),
+	HostnameField = field.StringField(
+		"hostname",
+		field.WithDescription("The Databricks hostname used to connect to the Databricks API"),
+		field.WithDefaultValue("cloud.databricks.com"),
+		field.WithDisplayName("Hostname"),
 	)
 	configFields = []field.SchemaField{
 		AccountHostnameField,
@@ -78,104 +42,13 @@ var (
 		DatabricksClientIdField,
 		DatabricksClientSecretField,
 		HostnameField,
-		PasswordField,
-		TokensField,
-		PersonalAccessTokenField,
-		UsernameField,
-		WorkspacesField,
-		WorkspaceIDField,
-	}
-	fieldRelationships = []field.SchemaFieldRelationship{
-		field.FieldsMutuallyExclusive(
-			DatabricksClientIdField,
-			UsernameField,
-			TokensField,
-			PersonalAccessTokenField,
-		),
-		field.FieldsRequiredTogether(
-			DatabricksClientIdField,
-			DatabricksClientSecretField,
-		),
-		field.FieldsRequiredTogether(
-			UsernameField,
-			PasswordField,
-		),
-		field.FieldsDependentOn(
-			[]field.SchemaField{TokensField},
-			[]field.SchemaField{WorkspacesField},
-		),
-		field.FieldsDependentOn(
-			[]field.SchemaField{PersonalAccessTokenField},
-			[]field.SchemaField{WorkspaceIDField},
-		),
-	}
-	fieldGroups = []field.SchemaFieldGroup{
-		{
-			Name:        "oauth-group",
-			DisplayName: "OAuth",
-			HelpText: "Authenticate using OAuth to sync information from all Databricks workspaces. " +
-				"Requires OAuth client ID and secret created following the Databricks OAuth authentication documentation.",
-			Fields: []field.SchemaField{
-				AccountIdField,
-				DatabricksClientIdField,
-				DatabricksClientSecretField,
-				AccountHostnameField,
-				HostnameField,
-			},
-			Default: true,
-		},
-		{
-			Name:        "personal-access-token-group",
-			DisplayName: "Personal access token",
-			HelpText:    "Authenticate using a personal access token to sync information from a single Databricks workspace. Requires a personal access token and the workspace ID.",
-			Fields: []field.SchemaField{
-				AccountIdField,
-				PersonalAccessTokenField,
-				WorkspaceIDField,
-				AccountHostnameField,
-				HostnameField,
-			},
-			Default: false,
-		},
-		{
-			Name:        "username-password-group",
-			DisplayName: "Username and password",
-			HelpText:    "Authenticate using your Databricks username and password to sync information from all Databricks workspaces.",
-			Fields: []field.SchemaField{
-				AccountIdField,
-				UsernameField,
-				PasswordField,
-				AccountHostnameField,
-				HostnameField,
-			},
-			Default: false,
-		},
 	}
 )
 
 //go:generate go run ./gen
 var Config = field.NewConfiguration(
 	configFields,
-	field.WithConstraints(fieldRelationships...),
-	field.WithFieldGroups(fieldGroups),
 	field.WithConnectorDisplayName("Databricks"),
 	field.WithHelpUrl("/docs/baton/databricks"),
 	field.WithIconUrl("/static/app-icons/databricks.svg"),
 )
-
-// ValidateConfig - additional validations that cannot be encoded in relationships (yet!)
-func ValidateConfig(ctx context.Context, cfg *Databricks) error {
-	workspaces := cfg.Workspaces
-	tokens := cfg.WorkspaceTokens
-
-	// If there are tokens, there must be an equivalent number of workspaces.
-	if len(tokens) > 0 && len(workspaces) != len(tokens) {
-		return fmt.Errorf(
-			"comma-separated list of workspaces and tokens must be the same length. Received %d workspaces and %d tokens",
-			len(workspaces),
-			len(tokens),
-		)
-	}
-
-	return nil
-}

--- a/pkg/connector/connector.go
+++ b/pkg/connector/connector.go
@@ -226,6 +226,11 @@ func NewConnector(ctx context.Context, cfg *config.Databricks, opts *cli.Connect
 	hostname := getHostname(cfg)
 	accountHostname := getAccountHostname(cfg, hostname)
 	auth := prepareClientAuth(ctx, cfg, l)
+	workspaces := cfg.Workspaces
+	workspaceID := cfg.WorkspaceId
+	if workspaceID != "" {
+		workspaces = []string{workspaceID}
+	}
 
 	cb, err := New(
 		ctx,
@@ -233,7 +238,7 @@ func NewConnector(ctx context.Context, cfg *config.Databricks, opts *cli.Connect
 		accountHostname,
 		cfg.AccountId,
 		auth,
-		cfg.Workspaces,
+		workspaces,
 	)
 	if err != nil {
 		l.Error("error creating connector", zap.Error(err))
@@ -254,9 +259,18 @@ func prepareClientAuth(_ context.Context, cfg *config.Databricks, l *zap.Logger)
 	databricksClientSecret := cfg.DatabricksClientSecret
 	username := cfg.Username
 	password := cfg.Password
-	workspaces := cfg.Workspaces
-	tokens := cfg.WorkspaceTokens
 	accountHostname := getAccountHostname(cfg, getHostname(cfg))
+
+	workspaces := cfg.Workspaces
+	workspaceID := cfg.WorkspaceId
+	if workspaceID != "" {
+		workspaces = []string{workspaceID}
+	}
+	tokens := cfg.WorkspaceTokens
+	personalAccessToken := cfg.PersonalAccessToken
+	if personalAccessToken != "" {
+		tokens = []string{personalAccessToken}
+	}
 
 	switch {
 	case username != "" && password != "":

--- a/pkg/databricks/auth.go
+++ b/pkg/databricks/auth.go
@@ -29,66 +29,6 @@ func (n *NoAuth) GetClient(ctx context.Context) (*http.Client, error) {
 	return httpClient, nil
 }
 
-type TokenAuth struct {
-	Tokens           map[string]string
-	CurrentWorkspace string
-}
-
-func NewTokenAuth(workspaces, tokens []string) *TokenAuth {
-	tokensMap := make(map[string]string)
-
-	for i, workspace := range workspaces {
-		tokensMap[workspace] = tokens[i]
-	}
-
-	return &TokenAuth{
-		Tokens:           tokensMap,
-		CurrentWorkspace: workspaces[0],
-	}
-}
-
-func (t *TokenAuth) Apply(req *http.Request) {
-	req.Header.Set("Authorization", fmt.Sprintf("Bearer %s", t.Tokens[t.CurrentWorkspace]))
-}
-
-func (t *TokenAuth) SetWorkspace(workspace string) {
-	t.CurrentWorkspace = workspace
-}
-
-func (t *TokenAuth) GetClient(ctx context.Context) (*http.Client, error) {
-	httpClient, err := uhttp.NewClient(ctx, uhttp.WithLogger(true, ctxzap.Extract(ctx)))
-	if err != nil {
-		return nil, err
-	}
-
-	return httpClient, nil
-}
-
-type BasicAuth struct {
-	Username string
-	Password string
-}
-
-func NewBasicAuth(username, password string) *BasicAuth {
-	return &BasicAuth{
-		Username: username,
-		Password: password,
-	}
-}
-
-func (b *BasicAuth) Apply(req *http.Request) {
-	req.SetBasicAuth(b.Username, b.Password)
-}
-
-func (b *BasicAuth) GetClient(ctx context.Context) (*http.Client, error) {
-	httpClient, err := uhttp.NewClient(ctx, uhttp.WithLogger(true, ctxzap.Extract(ctx)))
-	if err != nil {
-		return nil, err
-	}
-
-	return httpClient, nil
-}
-
 type OAuth2 struct {
 	cfg *clientcredentials.Config
 }

--- a/pkg/databricks/client.go
+++ b/pkg/databricks/client.go
@@ -94,11 +94,6 @@ func (c *Client) UpdateAvailability(accAPI, wsAPI bool) {
 	c.isWSAPIAvailable = wsAPI
 }
 
-func (c *Client) IsTokenAuth() bool {
-	_, ok := c.auth.(*TokenAuth)
-	return ok
-}
-
 func (c *Client) UpdateEtag(etag string) {
 	c.etag = etag
 }


### PR DESCRIPTION
**Change: Remove deprecated auth methods**
Previously, the connector supported three authentication methods. At this point, only OAuth is officially supported and not deprecated.
- Username/password authentication is no longer supported by Databricks.
- PAT-based authentication has also been deprecated (more recently), and while it may still technically work, it is no longer recommended.
- We confirmed that there are currently no customers using the PAT authentication method. Additionally, this approach is problematic because it requires maintaining workspace–PAT pairs in order to sync correctly.

Given these factors, the decision was made to remove the deprecated authentication methods and keep OAuth as the only supported option.

**Consequence: Field groups are no longer needed**
This change is still under evaluation. Lauren has been validating how this behaves in practice and whether existing support is sufficient or if additional handling is needed. This is something we will need to observe closely, and if required, add support to safely skip or handle field groups to avoid impacting customer credentials during the containerization rollouts.

-------------------------------------------------------------------------------------------------------------------------------------------

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Streamlined OAuth2-based authentication as the primary auth path.

* **Configuration**
  * New, clearer configuration fields for account ID, OAuth2 client ID/secret, and hostnames.

* **Breaking Changes**
  * Removed per-workspace token and username/password authentication and workspace-scoped configuration; connector no longer supports token/basic auth or explicit workspace lists.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->