### PR TITLE
docs: update style to match docs site

### DIFF
--- a/docs/connector.mdx
+++ b/docs/connector.mdx
@@ -73,7 +73,7 @@ You have three authentication choices when setting up the Databricks connector:
 
   You do not need to generate any additional credentials to use this method.
 
-**That's it!** Here's the set of credentials you'll need when setting up the connector:
+**Done.** Here's the set of credentials you'll need when setting up the connector:
 
 - Account ID
 - OAuth client ID
@@ -153,7 +153,7 @@ To complete this task, you'll need:
   </Step>
 </Steps>
 
-**That's it!** Your Databricks connector is now pulling access data into C1.
+**Done.** Your Databricks connector is now pulling access data into C1.
 
 </Tab>
 <Tab title="Self-hosted">
@@ -284,7 +284,7 @@ spec:
   </Step>
 </Steps>
 
-**That's it!** Your Databricks connector is now pulling access data into C1.
+**Done.** Your Databricks connector is now pulling access data into C1.
 
 </Tab>
 </Tabs>


### PR DESCRIPTION
## Summary

Syncs `docs/connector.mdx` style with the canonical docs site to prevent regressions on next release.

Changes applied where present:
- Docker image URL: `ghcr.io/conductorone/` → `public.ecr.aws/conductorone/`
- Phrasing: `**That's it!**` → `**Done.**`
- Icon color: `#65DE23` → `#c937ae`
- Branding: `ConductorOne` → `C1` in product references
- GitHub URLs: lowercased org name

These match the [docs site](https://docs.conductorone.com) and were identified via an automated sync audit.