### PR TITLE
CXH-2163: gracefully handle 403 on inaccessible workspaces

### DIFF
--- a/pkg/connector/groups.go
+++ b/pkg/connector/groups.go
@@ -48,11 +48,11 @@ func groupResource(ctx context.Context, group *databricks.Group, parent *v2.Reso
 		"parent_id":    parent.GetResource(),
 	}
 
-	groupTraitOptions := []rs.GroupTraitOption{
-		rs.WithGroupProfile(profile),
-	}
+	var groupTraitOptions []rs.GroupTraitOption
 
-	var options []rs.ResourceOption
+	options := []rs.ResourceOption{
+		rs.WithResourceProfile(profile),
+	}
 	if parent != nil {
 		options = append(options, rs.WithParentResourceID(parent))
 	}

--- a/pkg/connector/roles.go
+++ b/pkg/connector/roles.go
@@ -132,8 +132,6 @@ func (r *roleBuilder) Entitlements(
 	}, nil, nil
 }
 
-// isAPIErrorWithStatus reports whether err is (or wraps) a *databricks.APIError
-// whose StatusCode equals statusCode.
 func isAPIErrorWithStatus(err error, statusCode int) bool {
 	var apiErr *databricks.APIError
 	return errors.As(err, &apiErr) && apiErr.StatusCode == statusCode

--- a/pkg/connector/roles.go
+++ b/pkg/connector/roles.go
@@ -132,7 +132,7 @@ func (r *roleBuilder) Entitlements(
 	}, nil, nil
 }
 
-func isAPIErrorWithStatus(err error, statusCode int) bool {
+func isApiError(err error, statusCode int) bool {
 	var apiErr *databricks.APIError
 	return errors.As(err, &apiErr) && apiErr.StatusCode == statusCode
 }
@@ -193,7 +193,7 @@ func (r *roleBuilder) Grants(ctx context.Context, resource *v2.Resource, attr rs
 			databricks.NewUserRolesAttrVars(),
 		)
 		if err != nil {
-			if isWorkspaceRole && isAPIErrorWithStatus(err, http.StatusForbidden) {
+			if isWorkspaceRole && isApiError(err, http.StatusForbidden) {
 				l.Info("databricks-connector: workspace not accessible to service principal, skipping users",
 					zap.String("workspace_id", workspaceId))
 				users, total = nil, 0
@@ -235,7 +235,7 @@ func (r *roleBuilder) Grants(ctx context.Context, resource *v2.Resource, attr rs
 			databricks.NewGroupRolesAttrVars(),
 		)
 		if err != nil {
-			if isWorkspaceRole && isAPIErrorWithStatus(err, http.StatusForbidden) {
+			if isWorkspaceRole && isApiError(err, http.StatusForbidden) {
 				l.Info("databricks-connector: workspace not accessible to service principal, skipping groups",
 					zap.String("workspace_id", workspaceId))
 				groups, total = nil, 0
@@ -280,7 +280,7 @@ func (r *roleBuilder) Grants(ctx context.Context, resource *v2.Resource, attr rs
 			databricks.NewServicePrincipalRolesAttrVars(),
 		)
 		if err != nil {
-			if isWorkspaceRole && isAPIErrorWithStatus(err, http.StatusForbidden) {
+			if isWorkspaceRole && isApiError(err, http.StatusForbidden) {
 				l.Info("databricks-connector: workspace not accessible to service principal, skipping service principals",
 					zap.String("workspace_id", workspaceId))
 				servicePrincipals, total = nil, 0

--- a/pkg/connector/roles.go
+++ b/pkg/connector/roles.go
@@ -2,7 +2,9 @@ package connector
 
 import (
 	"context"
+	"errors"
 	"fmt"
+	"net/http"
 
 	"github.com/conductorone/baton-databricks/pkg/databricks"
 	v2 "github.com/conductorone/baton-sdk/pb/c1/connector/v2"
@@ -133,7 +135,17 @@ func (r *roleBuilder) Entitlements(
 // Grants returns all the grants for a given role.
 // Since Databricks API does not support listing grants for a role, so that it aligns with the sdk API,
 // we have to go through all the users, groups and servicePrincipals to check if they have the role.
+// isWorkspaceAccessForbidden reports whether err is a 403 from a workspace-scoped
+// API call. This happens when the service principal has account-level access but is
+// not an admin on that specific workspace; such workspaces are skipped so one
+// inaccessible workspace does not fail the whole sync.
+func isWorkspaceAccessForbidden(err error) bool {
+	var apiErr *databricks.APIError
+	return errors.As(err, &apiErr) && apiErr.StatusCode == http.StatusForbidden
+}
+
 func (r *roleBuilder) Grants(ctx context.Context, resource *v2.Resource, attr rs.SyncOpAttrs) ([]*v2.Grant, *rs.SyncOpResults, error) {
+	l := ctxzap.Extract(ctx)
 	var rv []*v2.Grant
 
 	roleTrait, err := rs.GetRoleTrait(resource)
@@ -185,7 +197,13 @@ func (r *roleBuilder) Grants(ctx context.Context, resource *v2.Resource, attr rs
 			databricks.NewUserRolesAttrVars(),
 		)
 		if err != nil {
-			return nil, nil, fmt.Errorf("databricks-connector: failed to list users: %w", err)
+			if isWorkspaceRole && isWorkspaceAccessForbidden(err) {
+				l.Info("databricks-connector: workspace not accessible to service principal, skipping users",
+					zap.String("workspace_id", workspaceId))
+				users, total = nil, 0
+			} else {
+				return nil, nil, fmt.Errorf("databricks-connector: failed to list users: %w", err)
+			}
 		}
 
 		// check if user has the role
@@ -221,7 +239,13 @@ func (r *roleBuilder) Grants(ctx context.Context, resource *v2.Resource, attr rs
 			databricks.NewGroupRolesAttrVars(),
 		)
 		if err != nil {
-			return nil, nil, fmt.Errorf("databricks-connector: failed to list groups: %w", err)
+			if isWorkspaceRole && isWorkspaceAccessForbidden(err) {
+				l.Info("databricks-connector: workspace not accessible to service principal, skipping groups",
+					zap.String("workspace_id", workspaceId))
+				groups, total = nil, 0
+			} else {
+				return nil, nil, fmt.Errorf("databricks-connector: failed to list groups: %w", err)
+			}
 		}
 
 		// check if group has the role
@@ -260,7 +284,13 @@ func (r *roleBuilder) Grants(ctx context.Context, resource *v2.Resource, attr rs
 			databricks.NewServicePrincipalRolesAttrVars(),
 		)
 		if err != nil {
-			return nil, nil, fmt.Errorf("databricks-connector: failed to list service principals: %w", err)
+			if isWorkspaceRole && isWorkspaceAccessForbidden(err) {
+				l.Info("databricks-connector: workspace not accessible to service principal, skipping service principals",
+					zap.String("workspace_id", workspaceId))
+				servicePrincipals, total = nil, 0
+			} else {
+				return nil, nil, fmt.Errorf("databricks-connector: failed to list service principals: %w", err)
+			}
 		}
 
 		// check if service principal has the role

--- a/pkg/connector/roles.go
+++ b/pkg/connector/roles.go
@@ -194,7 +194,7 @@ func (r *roleBuilder) Grants(ctx context.Context, resource *v2.Resource, attr rs
 		)
 		if err != nil {
 			if isWorkspaceRole && isApiError(err, http.StatusForbidden) {
-				l.Info("databricks-connector: workspace not accessible to service principal, skipping users",
+				l.Debug("databricks-connector: workspace not accessible to service principal, skipping users",
 					zap.String("workspace_id", workspaceId))
 				users, total = nil, 0
 			} else {
@@ -236,7 +236,7 @@ func (r *roleBuilder) Grants(ctx context.Context, resource *v2.Resource, attr rs
 		)
 		if err != nil {
 			if isWorkspaceRole && isApiError(err, http.StatusForbidden) {
-				l.Info("databricks-connector: workspace not accessible to service principal, skipping groups",
+				l.Debug("databricks-connector: workspace not accessible to service principal, skipping groups",
 					zap.String("workspace_id", workspaceId))
 				groups, total = nil, 0
 			} else {
@@ -281,7 +281,7 @@ func (r *roleBuilder) Grants(ctx context.Context, resource *v2.Resource, attr rs
 		)
 		if err != nil {
 			if isWorkspaceRole && isApiError(err, http.StatusForbidden) {
-				l.Info("databricks-connector: workspace not accessible to service principal, skipping service principals",
+				l.Debug("databricks-connector: workspace not accessible to service principal, skipping service principals",
 					zap.String("workspace_id", workspaceId))
 				servicePrincipals, total = nil, 0
 			} else {

--- a/pkg/connector/roles.go
+++ b/pkg/connector/roles.go
@@ -132,18 +132,16 @@ func (r *roleBuilder) Entitlements(
 	}, nil, nil
 }
 
+// isAPIErrorWithStatus reports whether err is (or wraps) a *databricks.APIError
+// whose StatusCode equals statusCode.
+func isAPIErrorWithStatus(err error, statusCode int) bool {
+	var apiErr *databricks.APIError
+	return errors.As(err, &apiErr) && apiErr.StatusCode == statusCode
+}
+
 // Grants returns all the grants for a given role.
 // Since Databricks API does not support listing grants for a role, so that it aligns with the sdk API,
 // we have to go through all the users, groups and servicePrincipals to check if they have the role.
-// isWorkspaceAccessForbidden reports whether err is a 403 from a workspace-scoped
-// API call. This happens when the service principal has account-level access but is
-// not an admin on that specific workspace; such workspaces are skipped so one
-// inaccessible workspace does not fail the whole sync.
-func isWorkspaceAccessForbidden(err error) bool {
-	var apiErr *databricks.APIError
-	return errors.As(err, &apiErr) && apiErr.StatusCode == http.StatusForbidden
-}
-
 func (r *roleBuilder) Grants(ctx context.Context, resource *v2.Resource, attr rs.SyncOpAttrs) ([]*v2.Grant, *rs.SyncOpResults, error) {
 	l := ctxzap.Extract(ctx)
 	var rv []*v2.Grant
@@ -197,7 +195,7 @@ func (r *roleBuilder) Grants(ctx context.Context, resource *v2.Resource, attr rs
 			databricks.NewUserRolesAttrVars(),
 		)
 		if err != nil {
-			if isWorkspaceRole && isWorkspaceAccessForbidden(err) {
+			if isWorkspaceRole && isAPIErrorWithStatus(err, http.StatusForbidden) {
 				l.Info("databricks-connector: workspace not accessible to service principal, skipping users",
 					zap.String("workspace_id", workspaceId))
 				users, total = nil, 0
@@ -239,7 +237,7 @@ func (r *roleBuilder) Grants(ctx context.Context, resource *v2.Resource, attr rs
 			databricks.NewGroupRolesAttrVars(),
 		)
 		if err != nil {
-			if isWorkspaceRole && isWorkspaceAccessForbidden(err) {
+			if isWorkspaceRole && isAPIErrorWithStatus(err, http.StatusForbidden) {
 				l.Info("databricks-connector: workspace not accessible to service principal, skipping groups",
 					zap.String("workspace_id", workspaceId))
 				groups, total = nil, 0
@@ -284,7 +282,7 @@ func (r *roleBuilder) Grants(ctx context.Context, resource *v2.Resource, attr rs
 			databricks.NewServicePrincipalRolesAttrVars(),
 		)
 		if err != nil {
-			if isWorkspaceRole && isWorkspaceAccessForbidden(err) {
+			if isWorkspaceRole && isAPIErrorWithStatus(err, http.StatusForbidden) {
 				l.Info("databricks-connector: workspace not accessible to service principal, skipping service principals",
 					zap.String("workspace_id", workspaceId))
 				servicePrincipals, total = nil, 0

--- a/pkg/connector/roles.go
+++ b/pkg/connector/roles.go
@@ -59,15 +59,14 @@ func roleResource(ctx context.Context, role string, parent *v2.ResourceId) (*v2.
 		roleID = role
 	}
 
-	roleTraitOptions := []rs.RoleTraitOption{
-		rs.WithRoleProfile(profile),
-	}
+	var roleTraitOptions []rs.RoleTraitOption
 
 	resource, err := rs.NewRoleResource(
 		role,
 		roleResourceType,
 		roleID,
 		roleTraitOptions,
+		rs.WithResourceProfile(profile),
 		rs.WithParentResourceID(parent),
 	)
 
@@ -144,12 +143,12 @@ func (r *roleBuilder) Grants(ctx context.Context, resource *v2.Resource, attr rs
 	l := ctxzap.Extract(ctx)
 	var rv []*v2.Grant
 
-	roleTrait, err := rs.GetRoleTrait(resource)
+	_, err := rs.GetRoleTrait(resource)
 	if err != nil {
 		return nil, nil, fmt.Errorf("databricks-connector: failed to get role trait: %w", err)
 	}
 
-	parentType, parentID, err := getParentInfoFromProfile(roleTrait.Profile)
+	parentType, parentID, err := getParentInfoFromProfile(rs.GetProfile(resource))
 	if err != nil {
 		return nil, nil, fmt.Errorf("databricks-connector: failed to get parent info from role profile: %w", err)
 	}
@@ -162,7 +161,7 @@ func (r *roleBuilder) Grants(ctx context.Context, resource *v2.Resource, attr rs
 		workspaceId = parentID
 	}
 
-	roleName, ok := rs.GetProfileStringValue(roleTrait.Profile, "role_name")
+	roleName, ok := rs.GetProfileStringValue(rs.GetProfile(resource), "role_name")
 	if !ok {
 		return nil, nil, fmt.Errorf("databricks-connector: failed to get role type from role profile")
 	}
@@ -339,12 +338,12 @@ func (r *roleBuilder) Grant(ctx context.Context, principal *v2.Resource, entitle
 		return nil, fmt.Errorf("databricks-connector: only users, groups and service principals can be granted role membership")
 	}
 
-	roleTrait, err := rs.GetRoleTrait(entitlement.Resource)
+	_, err := rs.GetRoleTrait(entitlement.Resource)
 	if err != nil {
 		return nil, fmt.Errorf("databricks-connector: failed to get role trait: %w", err)
 	}
 
-	parentType, parentID, err := getParentInfoFromProfile(roleTrait.Profile)
+	parentType, parentID, err := getParentInfoFromProfile(rs.GetProfile(entitlement.Resource))
 	if err != nil {
 		return nil, fmt.Errorf("databricks-connector: failed to get parent info from role profile: %w", err)
 	}
@@ -420,12 +419,12 @@ func (r *roleBuilder) Revoke(ctx context.Context, grant *v2.Grant) (annotations.
 		return nil, fmt.Errorf("databricks-connector: only users, groups and service principals can have role membership revoked")
 	}
 
-	roleTrait, err := rs.GetRoleTrait(entitlement.Resource)
+	_, err := rs.GetRoleTrait(entitlement.Resource)
 	if err != nil {
 		return nil, fmt.Errorf("databricks-connector: failed to get role trait: %w", err)
 	}
 
-	parentType, parentID, err := getParentInfoFromProfile(roleTrait.Profile)
+	parentType, parentID, err := getParentInfoFromProfile(rs.GetProfile(entitlement.Resource))
 	if err != nil {
 		return nil, fmt.Errorf("databricks-connector: failed to get parent info from role profile: %w", err)
 	}

--- a/pkg/connector/roles_test.go
+++ b/pkg/connector/roles_test.go
@@ -1,0 +1,32 @@
+package connector
+
+import (
+	"fmt"
+	"net/http"
+	"testing"
+
+	"github.com/conductorone/baton-databricks/pkg/databricks"
+)
+
+func TestIsWorkspaceAccessForbidden(t *testing.T) {
+	tests := []struct {
+		name string
+		err  error
+		want bool
+	}{
+		{"403 API error", &databricks.APIError{StatusCode: http.StatusForbidden}, true},
+		{"wrapped 403 API error", fmt.Errorf("list: %w", &databricks.APIError{StatusCode: http.StatusForbidden}), true},
+		{"400 API error", &databricks.APIError{StatusCode: http.StatusBadRequest}, false},
+		{"500 API error", &databricks.APIError{StatusCode: http.StatusInternalServerError}, false},
+		{"non-API error", fmt.Errorf("network timeout"), false},
+		{"nil error", nil, false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := isWorkspaceAccessForbidden(tt.err); got != tt.want {
+				t.Errorf("isWorkspaceAccessForbidden(%v) = %v, want %v", tt.err, got, tt.want)
+			}
+		})
+	}
+}

--- a/pkg/connector/roles_test.go
+++ b/pkg/connector/roles_test.go
@@ -8,7 +8,7 @@ import (
 	"github.com/conductorone/baton-databricks/pkg/databricks"
 )
 
-func TestIsAPIErrorWithStatus(t *testing.T) {
+func TestIsApiError(t *testing.T) {
 	tests := []struct {
 		name       string
 		err        error
@@ -26,8 +26,8 @@ func TestIsAPIErrorWithStatus(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if got := isAPIErrorWithStatus(tt.err, tt.statusCode); got != tt.want {
-				t.Errorf("isAPIErrorWithStatus(%v, %d) = %v, want %v", tt.err, tt.statusCode, got, tt.want)
+			if got := isApiError(tt.err, tt.statusCode); got != tt.want {
+				t.Errorf("isApiError(%v, %d) = %v, want %v", tt.err, tt.statusCode, got, tt.want)
 			}
 		})
 	}

--- a/pkg/connector/roles_test.go
+++ b/pkg/connector/roles_test.go
@@ -8,24 +8,26 @@ import (
 	"github.com/conductorone/baton-databricks/pkg/databricks"
 )
 
-func TestIsWorkspaceAccessForbidden(t *testing.T) {
+func TestIsAPIErrorWithStatus(t *testing.T) {
 	tests := []struct {
-		name string
-		err  error
-		want bool
+		name       string
+		err        error
+		statusCode int
+		want       bool
 	}{
-		{"403 API error", &databricks.APIError{StatusCode: http.StatusForbidden}, true},
-		{"wrapped 403 API error", fmt.Errorf("list: %w", &databricks.APIError{StatusCode: http.StatusForbidden}), true},
-		{"400 API error", &databricks.APIError{StatusCode: http.StatusBadRequest}, false},
-		{"500 API error", &databricks.APIError{StatusCode: http.StatusInternalServerError}, false},
-		{"non-API error", fmt.Errorf("network timeout"), false},
-		{"nil error", nil, false},
+		{"403 API error", &databricks.APIError{StatusCode: http.StatusForbidden}, http.StatusForbidden, true},
+		{"wrapped 403 API error", fmt.Errorf("list: %w", &databricks.APIError{StatusCode: http.StatusForbidden}), http.StatusForbidden, true},
+		{"403 API error, want 400", &databricks.APIError{StatusCode: http.StatusForbidden}, http.StatusBadRequest, false},
+		{"400 API error", &databricks.APIError{StatusCode: http.StatusBadRequest}, http.StatusForbidden, false},
+		{"500 API error", &databricks.APIError{StatusCode: http.StatusInternalServerError}, http.StatusForbidden, false},
+		{"non-API error", fmt.Errorf("network timeout"), http.StatusForbidden, false},
+		{"nil error", nil, http.StatusForbidden, false},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if got := isWorkspaceAccessForbidden(tt.err); got != tt.want {
-				t.Errorf("isWorkspaceAccessForbidden(%v) = %v, want %v", tt.err, got, tt.want)
+			if got := isAPIErrorWithStatus(tt.err, tt.statusCode); got != tt.want {
+				t.Errorf("isAPIErrorWithStatus(%v, %d) = %v, want %v", tt.err, tt.statusCode, got, tt.want)
 			}
 		})
 	}

--- a/pkg/connector/service-principals.go
+++ b/pkg/connector/service-principals.go
@@ -33,12 +33,12 @@ func (s *servicePrincipalBuilder) servicePrincipalResource(ctx context.Context, 
 		"parent_id":      parent.Resource,
 	}
 
-	servicePrincipalTraitOptions := []rs.GroupTraitOption{
-		rs.WithGroupProfile(profile),
-	}
+	var servicePrincipalTraitOptions []rs.GroupTraitOption
 
+	options := []rs.ResourceOption{
+		rs.WithResourceProfile(profile),
+	}
 	// keep the parent resource id, only if the parent resource is account
-	var options []rs.ResourceOption
 	if parent.ResourceType == accountResourceType.Id {
 		options = append(options, rs.WithParentResourceID(parent))
 	}
@@ -116,12 +116,12 @@ func (s *servicePrincipalBuilder) List(ctx context.Context, parentResourceID *v2
 func (s *servicePrincipalBuilder) Entitlements(_ context.Context, resource *v2.Resource, _ rs.SyncOpAttrs) ([]*v2.Entitlement, *rs.SyncOpResults, error) {
 	var rv []*v2.Entitlement
 
-	groupTrait, err := rs.GetGroupTrait(resource)
+	_, err := rs.GetGroupTrait(resource)
 	if err != nil {
 		return nil, nil, fmt.Errorf("databricks-connector: failed to get group trait: %w", err)
 	}
 
-	parentType, parentID, err := getParentInfoFromProfile(groupTrait.Profile)
+	parentType, parentID, err := getParentInfoFromProfile(rs.GetProfile(resource))
 	if err != nil {
 		return nil, nil, fmt.Errorf("databricks-connector: failed to get parent info from group profile: %w", err)
 	}
@@ -131,7 +131,7 @@ func (s *servicePrincipalBuilder) Entitlements(_ context.Context, resource *v2.R
 		workspaceId = parentID
 	}
 
-	applicationId, ok := rs.GetProfileStringValue(groupTrait.Profile, "application_id")
+	applicationId, ok := rs.GetProfileStringValue(rs.GetProfile(resource), "application_id")
 	if !ok {
 		return nil, nil, fmt.Errorf("databricks-connector: failed to get application_id from service principal profile")
 	}
@@ -161,12 +161,12 @@ func (s *servicePrincipalBuilder) Entitlements(_ context.Context, resource *v2.R
 func (s *servicePrincipalBuilder) Grants(ctx context.Context, resource *v2.Resource, _ rs.SyncOpAttrs) ([]*v2.Grant, *rs.SyncOpResults, error) {
 	l := ctxzap.Extract(ctx)
 
-	groupTrait, err := rs.GetGroupTrait(resource)
+	_, err := rs.GetGroupTrait(resource)
 	if err != nil {
 		return nil, nil, fmt.Errorf("databricks-connector: failed to get group trait: %w", err)
 	}
 
-	parentType, parentID, err := getParentInfoFromProfile(groupTrait.Profile)
+	parentType, parentID, err := getParentInfoFromProfile(rs.GetProfile(resource))
 	if err != nil {
 		return nil, nil, fmt.Errorf("databricks-connector: failed to get parent info from group profile: %w", err)
 	}
@@ -176,7 +176,7 @@ func (s *servicePrincipalBuilder) Grants(ctx context.Context, resource *v2.Resou
 		workspaceId = parentID
 	}
 
-	applicationId, ok := rs.GetProfileStringValue(groupTrait.Profile, "application_id")
+	applicationId, ok := rs.GetProfileStringValue(rs.GetProfile(resource), "application_id")
 	if !ok {
 		return nil, nil, fmt.Errorf("databricks-connector: failed to get application_id from service principal profile")
 	}
@@ -235,12 +235,12 @@ func (s *servicePrincipalBuilder) Grant(ctx context.Context, principal *v2.Resou
 		return nil, fmt.Errorf("databricks-connector: only users, groups and service principals can be granted service principal permissions")
 	}
 
-	groupTrait, err := rs.GetGroupTrait(entitlement.Resource)
+	_, err := rs.GetGroupTrait(entitlement.Resource)
 	if err != nil {
 		return nil, fmt.Errorf("databricks-connector: failed to get group trait: %w", err)
 	}
 
-	parentType, parentID, err := getParentInfoFromProfile(groupTrait.Profile)
+	parentType, parentID, err := getParentInfoFromProfile(rs.GetProfile(entitlement.Resource))
 	if err != nil {
 		return nil, fmt.Errorf("databricks-connector: failed to get parent info from group profile: %w", err)
 	}
@@ -250,7 +250,7 @@ func (s *servicePrincipalBuilder) Grant(ctx context.Context, principal *v2.Resou
 		workspaceId = parentID
 	}
 
-	applicationId, ok := rs.GetProfileStringValue(groupTrait.Profile, "application_id")
+	applicationId, ok := rs.GetProfileStringValue(rs.GetProfile(entitlement.Resource), "application_id")
 	if !ok {
 		return nil, fmt.Errorf("databricks-connector: failed to get application_id from service principal profile")
 	}
@@ -318,12 +318,12 @@ func (s *servicePrincipalBuilder) Revoke(ctx context.Context, grant *v2.Grant) (
 		return nil, fmt.Errorf("databricks-connector: only users, groups and service principals can have service principal permissions revoked")
 	}
 
-	groupTrait, err := rs.GetGroupTrait(entitlement.Resource)
+	_, err := rs.GetGroupTrait(entitlement.Resource)
 	if err != nil {
 		return nil, fmt.Errorf("databricks-connector: failed to get group trait: %w", err)
 	}
 
-	parentType, parentID, err := getParentInfoFromProfile(groupTrait.Profile)
+	parentType, parentID, err := getParentInfoFromProfile(rs.GetProfile(entitlement.Resource))
 	if err != nil {
 		return nil, fmt.Errorf("databricks-connector: failed to get parent info from group profile: %w", err)
 	}
@@ -333,7 +333,7 @@ func (s *servicePrincipalBuilder) Revoke(ctx context.Context, grant *v2.Grant) (
 		workspaceId = parentID
 	}
 
-	applicationId, ok := rs.GetProfileStringValue(groupTrait.Profile, "application_id")
+	applicationId, ok := rs.GetProfileStringValue(rs.GetProfile(entitlement.Resource), "application_id")
 	if !ok {
 		return nil, fmt.Errorf("databricks-connector: failed to get application_id from service principal profile")
 	}

--- a/pkg/connector/users.go
+++ b/pkg/connector/users.go
@@ -34,11 +34,11 @@ func (u *userBuilder) userResource(ctx context.Context, user *databricks.User, p
 		)
 	}
 
-	var status v2.UserTrait_Status_Status
+	var status v2.Status_ResourceStatus
 	if user.Active {
-		status = v2.UserTrait_Status_STATUS_ENABLED
+		status = v2.Status_RESOURCE_STATUS_ENABLED
 	} else {
-		status = v2.UserTrait_Status_STATUS_DISABLED
+		status = v2.Status_RESOURCE_STATUS_DISABLED
 	}
 
 	firstName, lastName := rs.SplitFullName(user.DisplayName)
@@ -51,16 +51,17 @@ func (u *userBuilder) userResource(ctx context.Context, user *databricks.User, p
 	}
 
 	userTraitOptions := []rs.UserTraitOption{
-		rs.WithUserProfile(profile),
-		rs.WithStatus(status),
 		rs.WithUserLogin(user.UserName),
 		rs.WithEmail(primaryEmail, true),
 	}
 
 	userTraitOptions = append(userTraitOptions, emailOptions...)
 
+	options := []rs.ResourceOption{
+		rs.WithResourceProfile(profile),
+		rs.WithResourceStatus(status, ""),
+	}
 	// keep the parent resource id, only if the parent resource is account
-	var options []rs.ResourceOption
 	if parent.ResourceType == accountResourceType.Id {
 		options = append(options, rs.WithParentResourceID(parent))
 	}

--- a/pkg/connector/workspaces.go
+++ b/pkg/connector/workspaces.go
@@ -39,9 +39,8 @@ func workspaceResource(_ context.Context, workspace *databricks.Workspace, paren
 		workspace.Name,
 		workspaceResourceType,
 		workspace.DeploymentName,
-		[]rs.GroupTraitOption{
-			rs.WithGroupProfile(profile),
-		},
+		nil,
+		rs.WithResourceProfile(profile),
 		rs.WithParentResourceID(parent),
 		rs.WithAnnotation(
 			&v2.ChildResourceType{ResourceTypeId: roleResourceType.Id},
@@ -111,12 +110,12 @@ func (w *workspaceBuilder) Grants(ctx context.Context, resource *v2.Resource, _ 
 		return nil, nil, nil
 	}
 
-	groupTrait, err := rs.GetGroupTrait(resource)
+	_, err := rs.GetGroupTrait(resource)
 	if err != nil {
 		return nil, nil, fmt.Errorf("databricks-connector: failed to get group trait: %w", err)
 	}
 
-	workspaceId, ok := rs.GetProfileInt64Value(groupTrait.Profile, "workspace_id")
+	workspaceId, ok := rs.GetProfileInt64Value(rs.GetProfile(resource), "workspace_id")
 	if !ok {
 		return nil, nil, fmt.Errorf("databricks-connector: failed to get workspace ID: %w", err)
 	}
@@ -195,12 +194,12 @@ func (w *workspaceBuilder) Grant(ctx context.Context, principal *v2.Resource, en
 		return nil, fmt.Errorf("databricks-connector: only users, groups and service principals can be granted workspace membership")
 	}
 
-	groupTrait, err := rs.GetGroupTrait(entitlement.Resource)
+	_, err := rs.GetGroupTrait(entitlement.Resource)
 	if err != nil {
 		return nil, fmt.Errorf("databricks-connector: failed to get group trait: %w", err)
 	}
 
-	workspaceID, ok := rs.GetProfileInt64Value(groupTrait.Profile, "workspace_id")
+	workspaceID, ok := rs.GetProfileInt64Value(rs.GetProfile(entitlement.Resource), "workspace_id")
 	if !ok {
 		return nil, fmt.Errorf("databricks-connector: failed to get workspace ID: %w", err)
 	}
@@ -230,12 +229,12 @@ func (w *workspaceBuilder) Revoke(ctx context.Context, grant *v2.Grant) (annotat
 		return nil, fmt.Errorf("databricks-connector: only users, groups and service principals can have workspace membership revoked")
 	}
 
-	groupTrait, err := rs.GetGroupTrait(entitlement.Resource)
+	_, err := rs.GetGroupTrait(entitlement.Resource)
 	if err != nil {
 		return nil, fmt.Errorf("databricks-connector: failed to get group trait: %w", err)
 	}
 
-	workspaceID, ok := rs.GetProfileInt64Value(groupTrait.Profile, "workspace_id")
+	workspaceID, ok := rs.GetProfileInt64Value(rs.GetProfile(entitlement.Resource), "workspace_id")
 	if !ok {
 		return nil, fmt.Errorf("databricks-connector: failed to get workspace ID: %w", err)
 	}


### PR DESCRIPTION
Databricks syncs no longer fail when the connector can read the account but lacks admin access to one workspace. That workspace's roles are skipped and the rest of the sync completes, instead of the whole sync erroring out.