### PR TITLE
CXH-2164: add workspace exclude flag to scope sync

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,6 +97,12 @@ both flags at the same time. If you do that, connector will sync with all
 workspaces that are associated with provided tokens and all workspaces that are
 in the list of workspaces.
 
+To instead exclude specific workspaces from the sync, pass them to the
+`--databricks-exclude-workspaces` flag (or the
+`BATON_DATABRICKS_EXCLUDE_WORKSPACES` environment variable) as a comma-separated
+list. Each entry can be a workspace name, deployment name, or numeric workspace
+ID. Excluded workspaces and their roles are skipped entirely.
+
 ## Group povisioning limitations
 provisioning of account groups from a workspace token is not supported, if you need to provision groups you can only do it using the client-id and client-secret flow,
 this is due to the fact that the Databricks API does not allow provisioning of groups from a workspace token.
@@ -132,6 +138,7 @@ Flags:
       --client-secret string              The client secret used to authenticate with ConductorOne ($BATON_CLIENT_SECRET)
       --databricks-client-id string       The Databricks service principal's client ID used to connect to the Databricks Account and Workspace API ($BATON_DATABRICKS_CLIENT_ID)
       --databricks-client-secret string   The Databricks service principal's client secret used to connect to the Databricks Account and Workspace API ($BATON_DATABRICKS_CLIENT_SECRET)
+      --databricks-exclude-workspaces strings   Workspaces to exclude from sync, identified by workspace name, deployment name, or numeric workspace ID ($BATON_DATABRICKS_EXCLUDE_WORKSPACES)
   -f, --file string                       The path to the c1z file to sync with ($BATON_FILE) (default "sync.c1z")
   -h, --help                              help for baton-databricks
       --hostname string                   The Databricks hostname used to connect to the Databricks API ($BATON_HOSTNAME) (default "cloud.databricks.com")

--- a/config_schema.json
+++ b/config_schema.json
@@ -139,6 +139,12 @@
       "stringField": {
         "defaultValue": "cloud.databricks.com"
       }
+    },
+    {
+      "name": "databricks-exclude-workspaces",
+      "displayName": "Exclude Workspaces",
+      "description": "Workspaces to exclude from sync, identified by workspace name, deployment name, or numeric workspace ID",
+      "stringSliceField": {}
     }
   ],
   "displayName": "Databricks",

--- a/docs/connector.mdx
+++ b/docs/connector.mdx
@@ -234,6 +234,9 @@ stringData:
   BATON_USERNAME: <Username for the Databricks account>
   BATON_PASSWORD: <Password for the Databricks account>
 
+  # Optional: comma-separated workspaces to exclude from sync (workspace name, deployment name, or numeric ID)
+  BATON_DATABRICKS_EXCLUDE_WORKSPACES: <workspace-a,workspace-b>
+
   # Optional: include if you want C1 to provision access using this connector
   BATON_PROVISIONING: true
 ```

--- a/pkg/config/conf.gen.go
+++ b/pkg/config/conf.gen.go
@@ -10,6 +10,7 @@ type Databricks struct {
 	DatabricksClientSecret string `mapstructure:"databricks-client-secret"`
 	Hostname string `mapstructure:"hostname"`
 	BaseUrl string `mapstructure:"base-url"`
+	DatabricksExcludeWorkspaces []string `mapstructure:"databricks-exclude-workspaces"`
 }
 
 func (c *Databricks) findFieldByTag(tagValue string) (any, bool) {

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -41,6 +41,11 @@ var (
 		field.WithHidden(true),
 		field.WithExportTarget(field.ExportTargetCLIOnly),
 	)
+	ExcludeWorkspacesField = field.StringSliceField(
+		"databricks-exclude-workspaces",
+		field.WithDescription("Workspaces to exclude from sync, identified by workspace name, deployment name, or numeric workspace ID"),
+		field.WithDisplayName("Exclude Workspaces"),
+	)
 	configFields = []field.SchemaField{
 		AccountHostnameField,
 		AccountIdField,
@@ -48,6 +53,7 @@ var (
 		DatabricksClientSecretField,
 		HostnameField,
 		BaseURLField,
+		ExcludeWorkspacesField,
 	}
 )
 

--- a/pkg/connector/connector.go
+++ b/pkg/connector/connector.go
@@ -147,13 +147,14 @@ func New(
 	accountID,
 	baseURL string,
 	auth databricks.Auth,
+	excludeWorkspaces []string,
 ) (*Databricks, error) {
 	httpClient, err := auth.GetClient(ctx)
 	if err != nil {
 		return nil, err
 	}
 
-	client, err := databricks.NewClient(ctx, httpClient, hostname, accountHostname, accountID, baseURL, auth)
+	client, err := databricks.NewClient(ctx, httpClient, hostname, accountHostname, accountID, baseURL, auth, excludeWorkspaces)
 	if err != nil {
 		return nil, err
 	}
@@ -177,6 +178,7 @@ func NewConnector(ctx context.Context, cfg *config.Databricks, opts *cli.Connect
 		cfg.AccountId,
 		cfg.BaseUrl,
 		auth,
+		cfg.DatabricksExcludeWorkspaces,
 	)
 	if err != nil {
 		l.Warn("error creating connector", zap.Error(err))

--- a/pkg/databricks/client.go
+++ b/pkg/databricks/client.go
@@ -103,17 +103,19 @@ func NewClient(ctx context.Context, httpClient *http.Client, hostname, accountHo
 
 // isWorkspaceExcluded case-insensitively matches w against the exclude set (name,
 // deployment name, or ID) — Databricks lowercases deployment_name but not workspace_name.
-func (c *Client) isWorkspaceExcluded(w Workspace) (string, bool) {
+// Returns every exclude-set key that matched, since a workspace can match more than one.
+func (c *Client) isWorkspaceExcluded(w Workspace) ([]string, bool) {
 	if len(c.excludeWorkspaces) == 0 {
-		return "", false
+		return nil, false
 	}
+	var keys []string
 	for _, key := range []string{w.Name, w.DeploymentName, strconv.Itoa(w.ID)} {
 		key = strings.ToLower(key)
 		if _, ok := c.excludeWorkspaces[key]; ok {
-			return key, true
+			keys = append(keys, key)
 		}
 	}
-	return "", false
+	return keys, len(keys) > 0
 }
 
 func (c *Client) workspaceUrl(workspaceId string) *url.URL {
@@ -553,8 +555,10 @@ func (c *Client) ListWorkspaces(
 	matched := make(map[string]struct{}, len(c.excludeWorkspaces))
 	filtered := make([]Workspace, 0, len(res))
 	for _, w := range res {
-		if key, ok := c.isWorkspaceExcluded(w); ok {
-			matched[key] = struct{}{}
+		if keys, ok := c.isWorkspaceExcluded(w); ok {
+			for _, key := range keys {
+				matched[key] = struct{}{}
+			}
 			continue
 		}
 		filtered = append(filtered, w)

--- a/pkg/databricks/client.go
+++ b/pkg/databricks/client.go
@@ -62,6 +62,7 @@ func NewClient(ctx context.Context, httpClient *http.Client, hostname, accountHo
 
 	excludeSet := make(map[string]struct{}, len(excludeWorkspaces))
 	for _, w := range excludeWorkspaces {
+		w = strings.TrimSpace(w)
 		if w == "" {
 			continue
 		}

--- a/pkg/databricks/client.go
+++ b/pkg/databricks/client.go
@@ -66,7 +66,7 @@ func NewClient(ctx context.Context, httpClient *http.Client, hostname, accountHo
 		if w == "" {
 			continue
 		}
-		excludeSet[w] = struct{}{}
+		excludeSet[strings.ToLower(w)] = struct{}{}
 	}
 
 	// If baseURL is provided, use it directly (for testing)
@@ -103,7 +103,7 @@ func (c *Client) isWorkspaceExcluded(w Workspace) bool {
 		return false
 	}
 	for _, key := range []string{w.Name, w.DeploymentName, strconv.Itoa(w.ID)} {
-		if _, ok := c.excludeWorkspaces[key]; ok {
+		if _, ok := c.excludeWorkspaces[strings.ToLower(key)]; ok {
 			return true
 		}
 	}

--- a/pkg/databricks/client.go
+++ b/pkg/databricks/client.go
@@ -8,6 +8,9 @@ import (
 	"strconv"
 	"strings"
 
+	"github.com/grpc-ecosystem/go-grpc-middleware/logging/zap/ctxzap"
+	"go.uber.org/zap"
+
 	v2 "github.com/conductorone/baton-sdk/pb/c1/connector/v2"
 	"github.com/conductorone/baton-sdk/pkg/uhttp"
 )
@@ -98,16 +101,19 @@ func NewClient(ctx context.Context, httpClient *http.Client, hostname, accountHo
 	}, err
 }
 
-func (c *Client) isWorkspaceExcluded(w Workspace) bool {
+// isWorkspaceExcluded case-insensitively matches w against the exclude set (name,
+// deployment name, or ID) — Databricks lowercases deployment_name but not workspace_name.
+func (c *Client) isWorkspaceExcluded(w Workspace) (string, bool) {
 	if len(c.excludeWorkspaces) == 0 {
-		return false
+		return "", false
 	}
 	for _, key := range []string{w.Name, w.DeploymentName, strconv.Itoa(w.ID)} {
-		if _, ok := c.excludeWorkspaces[strings.ToLower(key)]; ok {
-			return true
+		key = strings.ToLower(key)
+		if _, ok := c.excludeWorkspaces[key]; ok {
+			return key, true
 		}
 	}
-	return false
+	return "", false
 }
 
 func (c *Client) workspaceUrl(workspaceId string) *url.URL {
@@ -523,6 +529,8 @@ func (c *Client) ListRoles(
 	return res.Roles, ratelimitData, nil
 }
 
+// ListWorkspaces returns the account's workspaces, minus any excluded by the
+// databricks-exclude-workspaces field. GET /accounts/{id}/workspaces (unpaginated).
 func (c *Client) ListWorkspaces(
 	ctx context.Context,
 ) (
@@ -542,13 +550,26 @@ func (c *Client) ListWorkspaces(
 		return res, ratelimitData, nil
 	}
 
+	matched := make(map[string]struct{}, len(c.excludeWorkspaces))
 	filtered := make([]Workspace, 0, len(res))
 	for _, w := range res {
-		if c.isWorkspaceExcluded(w) {
+		if key, ok := c.isWorkspaceExcluded(w); ok {
+			matched[key] = struct{}{}
 			continue
 		}
 		filtered = append(filtered, w)
 	}
+
+	unmatched := make([]string, 0, len(c.excludeWorkspaces))
+	for key := range c.excludeWorkspaces {
+		if _, ok := matched[key]; !ok {
+			unmatched = append(unmatched, key)
+		}
+	}
+	ctxzap.Extract(ctx).Debug("databricks: applied workspace exclusions",
+		zap.Int("excluded", len(res)-len(filtered)),
+		zap.Strings("unmatched_exclude_entries", unmatched),
+	)
 
 	return filtered, ratelimitData, nil
 }

--- a/pkg/databricks/client.go
+++ b/pkg/databricks/client.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"net/http"
 	"net/url"
+	"strconv"
 	"strings"
 
 	v2 "github.com/conductorone/baton-sdk/pb/c1/connector/v2"
@@ -34,12 +35,13 @@ const (
 )
 
 type Client struct {
-	httpClient     *uhttp.BaseHttpClient
-	baseUrl        *url.URL
-	accountBaseUrl *url.URL
-	auth           Auth
-	etag           string
-	accountId      string
+	httpClient        *uhttp.BaseHttpClient
+	baseUrl           *url.URL
+	accountBaseUrl    *url.URL
+	auth              Auth
+	etag              string
+	accountId         string
+	excludeWorkspaces map[string]struct{}
 
 	isAccAPIAvailable bool
 	isWSAPIAvailable  bool
@@ -54,9 +56,17 @@ func GetAccountHostname(hostname string) string {
 	return "accounts." + hostname
 }
 
-func NewClient(ctx context.Context, httpClient *http.Client, hostname, accountHostname, accountID, baseURL string, auth Auth) (*Client, error) {
+func NewClient(ctx context.Context, httpClient *http.Client, hostname, accountHostname, accountID, baseURL string, auth Auth, excludeWorkspaces []string) (*Client, error) {
 	var baseUrl *url.URL
 	var err error
+
+	excludeSet := make(map[string]struct{}, len(excludeWorkspaces))
+	for _, w := range excludeWorkspaces {
+		if w == "" {
+			continue
+		}
+		excludeSet[w] = struct{}{}
+	}
 
 	// If baseURL is provided, use it directly (for testing)
 	if baseURL != "" {
@@ -78,12 +88,25 @@ func NewClient(ctx context.Context, httpClient *http.Client, hostname, accountHo
 
 	cli, err := uhttp.NewBaseHttpClientWithContext(ctx, httpClient)
 	return &Client{
-		httpClient:     cli,
-		auth:           auth,
-		accountId:      accountID,
-		accountBaseUrl: accountBaseUrl,
-		baseUrl:        baseUrl,
+		httpClient:        cli,
+		auth:              auth,
+		accountId:         accountID,
+		accountBaseUrl:    accountBaseUrl,
+		baseUrl:           baseUrl,
+		excludeWorkspaces: excludeSet,
 	}, err
+}
+
+func (c *Client) isWorkspaceExcluded(w Workspace) bool {
+	if len(c.excludeWorkspaces) == 0 {
+		return false
+	}
+	for _, key := range []string{w.Name, w.DeploymentName, strconv.Itoa(w.ID)} {
+		if _, ok := c.excludeWorkspaces[key]; ok {
+			return true
+		}
+	}
+	return false
 }
 
 func (c *Client) workspaceUrl(workspaceId string) *url.URL {
@@ -514,7 +537,19 @@ func (c *Client) ListWorkspaces(
 		return nil, ratelimitData, err
 	}
 
-	return res, ratelimitData, nil
+	if len(c.excludeWorkspaces) == 0 {
+		return res, ratelimitData, nil
+	}
+
+	filtered := make([]Workspace, 0, len(res))
+	for _, w := range res {
+		if c.isWorkspaceExcluded(w) {
+			continue
+		}
+		filtered = append(filtered, w)
+	}
+
+	return filtered, ratelimitData, nil
 }
 
 func (c *Client) ListWorkspaceMembers(

--- a/pkg/databricks/client_test.go
+++ b/pkg/databricks/client_test.go
@@ -43,3 +43,23 @@ func TestIsWorkspaceExcluded(t *testing.T) {
 		})
 	}
 }
+
+func TestIsWorkspaceExcludedReturnsEveryMatchedKey(t *testing.T) {
+	ws := Workspace{ID: 12345, Name: "prod", DeploymentName: "dbc-abc"}
+	c := newTestClient(t, []string{"prod", "dbc-abc", "staging"})
+
+	keys, ok := c.isWorkspaceExcluded(ws)
+	if !ok {
+		t.Fatalf("isWorkspaceExcluded(%+v) = false, want true", ws)
+	}
+	want := []string{"prod", "dbc-abc"}
+	if len(keys) != len(want) {
+		t.Fatalf("isWorkspaceExcluded(%+v) matched keys = %v, want %v", ws, keys, want)
+	}
+	for i, k := range want {
+		if keys[i] != k {
+			t.Errorf("isWorkspaceExcluded(%+v) matched keys = %v, want %v", ws, keys, want)
+			break
+		}
+	}
+}

--- a/pkg/databricks/client_test.go
+++ b/pkg/databricks/client_test.go
@@ -37,7 +37,7 @@ func TestIsWorkspaceExcluded(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			c := newTestClient(t, tt.exclude)
-			if got := c.isWorkspaceExcluded(ws); got != tt.want {
+			if _, got := c.isWorkspaceExcluded(ws); got != tt.want {
 				t.Errorf("isWorkspaceExcluded(%+v) with exclude %v = %v, want %v", ws, tt.exclude, got, tt.want)
 			}
 		})

--- a/pkg/databricks/client_test.go
+++ b/pkg/databricks/client_test.go
@@ -1,0 +1,43 @@
+package databricks
+
+import (
+	"context"
+	"net/http"
+	"testing"
+)
+
+func newTestClient(t *testing.T, exclude []string) *Client {
+	t.Helper()
+	c, err := NewClient(context.Background(), &http.Client{}, "example.cloud.databricks.com", "accounts.cloud.databricks.com", "acc-1", "", nil, exclude)
+	if err != nil {
+		t.Fatalf("NewClient: %v", err)
+	}
+	return c
+}
+
+func TestIsWorkspaceExcluded(t *testing.T) {
+	ws := Workspace{ID: 12345, Name: "prod", DeploymentName: "dbc-abc"}
+
+	tests := []struct {
+		name    string
+		exclude []string
+		want    bool
+	}{
+		{"no exclusions", nil, false},
+		{"by name", []string{"prod"}, true},
+		{"by deployment name", []string{"dbc-abc"}, true},
+		{"by numeric id", []string{"12345"}, true},
+		{"no match", []string{"staging"}, false},
+		{"empty and whitespace entries ignored", []string{"", "   "}, false},
+		{"space-padded entry still matches", []string{" prod"}, true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			c := newTestClient(t, tt.exclude)
+			if got := c.isWorkspaceExcluded(ws); got != tt.want {
+				t.Errorf("isWorkspaceExcluded(%+v) with exclude %v = %v, want %v", ws, tt.exclude, got, tt.want)
+			}
+		})
+	}
+}

--- a/pkg/databricks/client_test.go
+++ b/pkg/databricks/client_test.go
@@ -30,6 +30,8 @@ func TestIsWorkspaceExcluded(t *testing.T) {
 		{"no match", []string{"staging"}, false},
 		{"empty and whitespace entries ignored", []string{"", "   "}, false},
 		{"space-padded entry still matches", []string{" prod"}, true},
+		{"name match is case-insensitive", []string{"PROD"}, true},
+		{"deployment name match is case-insensitive", []string{"DBC-ABC"}, true},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
Customers can now exclude specific Databricks workspaces from a sync by name or ID, so an inaccessible or unwanted workspace no longer has to be synced or granted access to.