### PR TITLE
CXH-2165: fix Databricks account host for Azure and GCP tenants

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,7 +126,7 @@ Available Commands:
   help               Help about any command
 
 Flags:
-      --account-hostname string           The hostname used to connect to the Databricks account API ($BATON_ACCOUNT_HOSTNAME) (default "accounts.cloud.databricks.com")
+      --account-hostname string           The hostname used to connect to the Databricks account API. If not set, it will be calculated from the hostname field. ($BATON_ACCOUNT_HOSTNAME)
       --account-id string                 required: The Databricks account ID used to connect to the Databricks Account and Workspace API ($BATON_ACCOUNT_ID)
       --client-id string                  The client ID used to authenticate with ConductorOne ($BATON_CLIENT_ID)
       --client-secret string              The client secret used to authenticate with ConductorOne ($BATON_CLIENT_SECRET)

--- a/config_schema.json
+++ b/config_schema.json
@@ -96,9 +96,7 @@
       "name": "account-hostname",
       "displayName": "Account Hostname",
       "description": "The hostname used to connect to the Databricks account API. If not set, it will be calculated from the hostname field.",
-      "stringField": {
-        "defaultValue": "accounts.cloud.databricks.com"
-      }
+      "stringField": {}
     },
     {
       "name": "account-id",

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -26,7 +26,6 @@ var (
 	)
 	AccountHostnameField = field.StringField(
 		"account-hostname",
-		field.WithDefaultValue("accounts.cloud.databricks.com"),
 		field.WithDescription("The hostname used to connect to the Databricks account API. If not set, it will be calculated from the hostname field."),
 		field.WithDisplayName("Account Hostname"),
 	)

--- a/pkg/connector/connector_test.go
+++ b/pkg/connector/connector_test.go
@@ -1,0 +1,37 @@
+package connector
+
+import (
+	"testing"
+
+	"github.com/conductorone/baton-databricks/pkg/config"
+)
+
+// Regression for CXH-2165: with account-hostname unset the Azure/GCP hostname
+// calculation must run. A non-empty field default here silently masks it.
+func TestGetAccountHostname(t *testing.T) {
+	cases := []struct {
+		name            string
+		accountHostname string
+		hostname        string
+		want            string
+	}{
+		{"explicit override honored", "accounts.custom.example.com", "cloud.databricks.com", "accounts.custom.example.com"},
+		{"unset azure calculates", "", "myorg.azuredatabricks.net", "accounts.azuredatabricks.net"},
+		{"unset gcp calculates", "", "myorg.gcp.databricks.net", "accounts.gcp.databricks.net"},
+		{"unset aws calculates", "", "cloud.databricks.com", "accounts.cloud.databricks.com"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			cfg := &config.Databricks{AccountHostname: tc.accountHostname}
+			if got := getAccountHostname(cfg, tc.hostname); got != tc.want {
+				t.Errorf("getAccountHostname() = %q, want %q", got, tc.want)
+			}
+		})
+	}
+}
+
+func TestAccountHostnameFieldHasNoDefault(t *testing.T) {
+	if v := config.AccountHostnameField.DefaultValue; v != nil && v != "" {
+		t.Errorf("account-hostname field must have no default, got %q", v)
+	}
+}

--- a/pkg/connector/connector_test.go
+++ b/pkg/connector/connector_test.go
@@ -17,7 +17,7 @@ func TestGetAccountHostname(t *testing.T) {
 	}{
 		{"explicit override honored", "accounts.custom.example.com", "cloud.databricks.com", "accounts.custom.example.com"},
 		{"unset azure calculates", "", "myorg.azuredatabricks.net", "accounts.azuredatabricks.net"},
-		{"unset gcp calculates", "", "myorg.gcp.databricks.net", "accounts.gcp.databricks.net"},
+		{"unset gcp calculates", "", "myorg.gcp.databricks.com", "accounts.gcp.databricks.com"},
 		{"unset aws calculates", "", "cloud.databricks.com", "accounts.cloud.databricks.com"},
 	}
 	for _, tc := range cases {

--- a/pkg/connector/groups.go
+++ b/pkg/connector/groups.go
@@ -48,11 +48,9 @@ func groupResource(ctx context.Context, group *databricks.Group, parent *v2.Reso
 		"parent_id":    parent.GetResource(),
 	}
 
-	groupTraitOptions := []rs.GroupTraitOption{
-		rs.WithGroupProfile(profile),
+	options := []rs.ResourceOption{
+		rs.WithResourceProfile(profile),
 	}
-
-	var options []rs.ResourceOption
 	if parent != nil {
 		options = append(options, rs.WithParentResourceID(parent))
 	}
@@ -62,7 +60,7 @@ func groupResource(ctx context.Context, group *databricks.Group, parent *v2.Reso
 		group.DisplayName,
 		groupResourceType,
 		groupId,
-		groupTraitOptions,
+		nil,
 		options...,
 	)
 

--- a/pkg/connector/roles.go
+++ b/pkg/connector/roles.go
@@ -57,16 +57,13 @@ func roleResource(ctx context.Context, role string, parent *v2.ResourceId) (*v2.
 		roleID = role
 	}
 
-	roleTraitOptions := []rs.RoleTraitOption{
-		rs.WithRoleProfile(profile),
-	}
-
 	resource, err := rs.NewRoleResource(
 		role,
 		roleResourceType,
 		roleID,
-		roleTraitOptions,
+		nil,
 		rs.WithParentResourceID(parent),
+		rs.WithResourceProfile(profile),
 	)
 
 	if err != nil {
@@ -136,12 +133,9 @@ func (r *roleBuilder) Entitlements(
 func (r *roleBuilder) Grants(ctx context.Context, resource *v2.Resource, attr rs.SyncOpAttrs) ([]*v2.Grant, *rs.SyncOpResults, error) {
 	var rv []*v2.Grant
 
-	roleTrait, err := rs.GetRoleTrait(resource)
-	if err != nil {
-		return nil, nil, fmt.Errorf("databricks-connector: failed to get role trait: %w", err)
-	}
+	profile := rs.GetProfile(resource)
 
-	parentType, parentID, err := getParentInfoFromProfile(roleTrait.Profile)
+	parentType, parentID, err := getParentInfoFromProfile(profile)
 	if err != nil {
 		return nil, nil, fmt.Errorf("databricks-connector: failed to get parent info from role profile: %w", err)
 	}
@@ -154,7 +148,7 @@ func (r *roleBuilder) Grants(ctx context.Context, resource *v2.Resource, attr rs
 		workspaceId = parentID
 	}
 
-	roleName, ok := rs.GetProfileStringValue(roleTrait.Profile, "role_name")
+	roleName, ok := rs.GetProfileStringValue(profile, "role_name")
 	if !ok {
 		return nil, nil, fmt.Errorf("databricks-connector: failed to get role type from role profile")
 	}
@@ -313,12 +307,7 @@ func (r *roleBuilder) Grant(ctx context.Context, principal *v2.Resource, entitle
 		return nil, fmt.Errorf("databricks-connector: only users, groups and service principals can be granted role membership")
 	}
 
-	roleTrait, err := rs.GetRoleTrait(entitlement.Resource)
-	if err != nil {
-		return nil, fmt.Errorf("databricks-connector: failed to get role trait: %w", err)
-	}
-
-	parentType, parentID, err := getParentInfoFromProfile(roleTrait.Profile)
+	parentType, parentID, err := getParentInfoFromProfile(rs.GetProfile(entitlement.Resource))
 	if err != nil {
 		return nil, fmt.Errorf("databricks-connector: failed to get parent info from role profile: %w", err)
 	}
@@ -394,12 +383,7 @@ func (r *roleBuilder) Revoke(ctx context.Context, grant *v2.Grant) (annotations.
 		return nil, fmt.Errorf("databricks-connector: only users, groups and service principals can have role membership revoked")
 	}
 
-	roleTrait, err := rs.GetRoleTrait(entitlement.Resource)
-	if err != nil {
-		return nil, fmt.Errorf("databricks-connector: failed to get role trait: %w", err)
-	}
-
-	parentType, parentID, err := getParentInfoFromProfile(roleTrait.Profile)
+	parentType, parentID, err := getParentInfoFromProfile(rs.GetProfile(entitlement.Resource))
 	if err != nil {
 		return nil, fmt.Errorf("databricks-connector: failed to get parent info from role profile: %w", err)
 	}

--- a/pkg/connector/service-principals.go
+++ b/pkg/connector/service-principals.go
@@ -33,12 +33,10 @@ func (s *servicePrincipalBuilder) servicePrincipalResource(ctx context.Context, 
 		"parent_id":      parent.Resource,
 	}
 
-	servicePrincipalTraitOptions := []rs.GroupTraitOption{
-		rs.WithGroupProfile(profile),
+	options := []rs.ResourceOption{
+		rs.WithResourceProfile(profile),
 	}
-
 	// keep the parent resource id, only if the parent resource is account
-	var options []rs.ResourceOption
 	if parent.ResourceType == accountResourceType.Id {
 		options = append(options, rs.WithParentResourceID(parent))
 	}
@@ -54,7 +52,7 @@ func (s *servicePrincipalBuilder) servicePrincipalResource(ctx context.Context, 
 		servicePrincipal.DisplayName,
 		servicePrincipalResourceType,
 		servicePrincipal.ID,
-		servicePrincipalTraitOptions,
+		nil,
 		options...,
 	)
 
@@ -116,12 +114,9 @@ func (s *servicePrincipalBuilder) List(ctx context.Context, parentResourceID *v2
 func (s *servicePrincipalBuilder) Entitlements(_ context.Context, resource *v2.Resource, _ rs.SyncOpAttrs) ([]*v2.Entitlement, *rs.SyncOpResults, error) {
 	var rv []*v2.Entitlement
 
-	groupTrait, err := rs.GetGroupTrait(resource)
-	if err != nil {
-		return nil, nil, fmt.Errorf("databricks-connector: failed to get group trait: %w", err)
-	}
+	profile := rs.GetProfile(resource)
 
-	parentType, parentID, err := getParentInfoFromProfile(groupTrait.Profile)
+	parentType, parentID, err := getParentInfoFromProfile(profile)
 	if err != nil {
 		return nil, nil, fmt.Errorf("databricks-connector: failed to get parent info from group profile: %w", err)
 	}
@@ -131,7 +126,7 @@ func (s *servicePrincipalBuilder) Entitlements(_ context.Context, resource *v2.R
 		workspaceId = parentID
 	}
 
-	applicationId, ok := rs.GetProfileStringValue(groupTrait.Profile, "application_id")
+	applicationId, ok := rs.GetProfileStringValue(profile, "application_id")
 	if !ok {
 		return nil, nil, fmt.Errorf("databricks-connector: failed to get application_id from service principal profile")
 	}
@@ -161,12 +156,9 @@ func (s *servicePrincipalBuilder) Entitlements(_ context.Context, resource *v2.R
 func (s *servicePrincipalBuilder) Grants(ctx context.Context, resource *v2.Resource, _ rs.SyncOpAttrs) ([]*v2.Grant, *rs.SyncOpResults, error) {
 	l := ctxzap.Extract(ctx)
 
-	groupTrait, err := rs.GetGroupTrait(resource)
-	if err != nil {
-		return nil, nil, fmt.Errorf("databricks-connector: failed to get group trait: %w", err)
-	}
+	profile := rs.GetProfile(resource)
 
-	parentType, parentID, err := getParentInfoFromProfile(groupTrait.Profile)
+	parentType, parentID, err := getParentInfoFromProfile(profile)
 	if err != nil {
 		return nil, nil, fmt.Errorf("databricks-connector: failed to get parent info from group profile: %w", err)
 	}
@@ -176,7 +168,7 @@ func (s *servicePrincipalBuilder) Grants(ctx context.Context, resource *v2.Resou
 		workspaceId = parentID
 	}
 
-	applicationId, ok := rs.GetProfileStringValue(groupTrait.Profile, "application_id")
+	applicationId, ok := rs.GetProfileStringValue(profile, "application_id")
 	if !ok {
 		return nil, nil, fmt.Errorf("databricks-connector: failed to get application_id from service principal profile")
 	}
@@ -235,12 +227,9 @@ func (s *servicePrincipalBuilder) Grant(ctx context.Context, principal *v2.Resou
 		return nil, fmt.Errorf("databricks-connector: only users, groups and service principals can be granted service principal permissions")
 	}
 
-	groupTrait, err := rs.GetGroupTrait(entitlement.Resource)
-	if err != nil {
-		return nil, fmt.Errorf("databricks-connector: failed to get group trait: %w", err)
-	}
+	profile := rs.GetProfile(entitlement.Resource)
 
-	parentType, parentID, err := getParentInfoFromProfile(groupTrait.Profile)
+	parentType, parentID, err := getParentInfoFromProfile(profile)
 	if err != nil {
 		return nil, fmt.Errorf("databricks-connector: failed to get parent info from group profile: %w", err)
 	}
@@ -250,7 +239,7 @@ func (s *servicePrincipalBuilder) Grant(ctx context.Context, principal *v2.Resou
 		workspaceId = parentID
 	}
 
-	applicationId, ok := rs.GetProfileStringValue(groupTrait.Profile, "application_id")
+	applicationId, ok := rs.GetProfileStringValue(profile, "application_id")
 	if !ok {
 		return nil, fmt.Errorf("databricks-connector: failed to get application_id from service principal profile")
 	}
@@ -318,12 +307,9 @@ func (s *servicePrincipalBuilder) Revoke(ctx context.Context, grant *v2.Grant) (
 		return nil, fmt.Errorf("databricks-connector: only users, groups and service principals can have service principal permissions revoked")
 	}
 
-	groupTrait, err := rs.GetGroupTrait(entitlement.Resource)
-	if err != nil {
-		return nil, fmt.Errorf("databricks-connector: failed to get group trait: %w", err)
-	}
+	profile := rs.GetProfile(entitlement.Resource)
 
-	parentType, parentID, err := getParentInfoFromProfile(groupTrait.Profile)
+	parentType, parentID, err := getParentInfoFromProfile(profile)
 	if err != nil {
 		return nil, fmt.Errorf("databricks-connector: failed to get parent info from group profile: %w", err)
 	}
@@ -333,7 +319,7 @@ func (s *servicePrincipalBuilder) Revoke(ctx context.Context, grant *v2.Grant) (
 		workspaceId = parentID
 	}
 
-	applicationId, ok := rs.GetProfileStringValue(groupTrait.Profile, "application_id")
+	applicationId, ok := rs.GetProfileStringValue(profile, "application_id")
 	if !ok {
 		return nil, fmt.Errorf("databricks-connector: failed to get application_id from service principal profile")
 	}

--- a/pkg/connector/users.go
+++ b/pkg/connector/users.go
@@ -34,11 +34,11 @@ func (u *userBuilder) userResource(ctx context.Context, user *databricks.User, p
 		)
 	}
 
-	var status v2.UserTrait_Status_Status
+	var status v2.Status_ResourceStatus
 	if user.Active {
-		status = v2.UserTrait_Status_STATUS_ENABLED
+		status = v2.Status_RESOURCE_STATUS_ENABLED
 	} else {
-		status = v2.UserTrait_Status_STATUS_DISABLED
+		status = v2.Status_RESOURCE_STATUS_DISABLED
 	}
 
 	firstName, lastName := rs.SplitFullName(user.DisplayName)
@@ -51,16 +51,17 @@ func (u *userBuilder) userResource(ctx context.Context, user *databricks.User, p
 	}
 
 	userTraitOptions := []rs.UserTraitOption{
-		rs.WithUserProfile(profile),
-		rs.WithStatus(status),
 		rs.WithUserLogin(user.UserName),
 		rs.WithEmail(primaryEmail, true),
 	}
 
 	userTraitOptions = append(userTraitOptions, emailOptions...)
 
+	options := []rs.ResourceOption{
+		rs.WithResourceProfile(profile),
+		rs.WithResourceStatus(status, ""),
+	}
 	// keep the parent resource id, only if the parent resource is account
-	var options []rs.ResourceOption
 	if parent.ResourceType == accountResourceType.Id {
 		options = append(options, rs.WithParentResourceID(parent))
 	}

--- a/pkg/connector/workspaces.go
+++ b/pkg/connector/workspaces.go
@@ -39,9 +39,8 @@ func workspaceResource(_ context.Context, workspace *databricks.Workspace, paren
 		workspace.Name,
 		workspaceResourceType,
 		workspace.DeploymentName,
-		[]rs.GroupTraitOption{
-			rs.WithGroupProfile(profile),
-		},
+		nil,
+		rs.WithResourceProfile(profile),
 		rs.WithParentResourceID(parent),
 		rs.WithAnnotation(
 			&v2.ChildResourceType{ResourceTypeId: roleResourceType.Id},
@@ -111,14 +110,11 @@ func (w *workspaceBuilder) Grants(ctx context.Context, resource *v2.Resource, _ 
 		return nil, nil, nil
 	}
 
-	groupTrait, err := rs.GetGroupTrait(resource)
-	if err != nil {
-		return nil, nil, fmt.Errorf("databricks-connector: failed to get group trait: %w", err)
-	}
+	profile := rs.GetProfile(resource)
 
-	workspaceId, ok := rs.GetProfileInt64Value(groupTrait.Profile, "workspace_id")
+	workspaceId, ok := rs.GetProfileInt64Value(profile, "workspace_id")
 	if !ok {
-		return nil, nil, fmt.Errorf("databricks-connector: failed to get workspace ID: %w", err)
+		return nil, nil, fmt.Errorf("databricks-connector: failed to get workspace ID")
 	}
 
 	workspace := strconv.Itoa(int(workspaceId))
@@ -195,18 +191,15 @@ func (w *workspaceBuilder) Grant(ctx context.Context, principal *v2.Resource, en
 		return nil, fmt.Errorf("databricks-connector: only users, groups and service principals can be granted workspace membership")
 	}
 
-	groupTrait, err := rs.GetGroupTrait(entitlement.Resource)
-	if err != nil {
-		return nil, fmt.Errorf("databricks-connector: failed to get group trait: %w", err)
-	}
+	profile := rs.GetProfile(entitlement.Resource)
 
-	workspaceID, ok := rs.GetProfileInt64Value(groupTrait.Profile, "workspace_id")
+	workspaceID, ok := rs.GetProfileInt64Value(profile, "workspace_id")
 	if !ok {
-		return nil, fmt.Errorf("databricks-connector: failed to get workspace ID: %w", err)
+		return nil, fmt.Errorf("databricks-connector: failed to get workspace ID")
 	}
 
 	workspace := strconv.Itoa(int(workspaceID))
-	_, err = w.client.CreateOrUpdateWorkspaceMember(ctx, workspace, principal.Id.Resource)
+	_, err := w.client.CreateOrUpdateWorkspaceMember(ctx, workspace, principal.Id.Resource)
 	if err != nil {
 		return nil, fmt.Errorf("databricks-connector: failed to create or update workspace member: %w", err)
 	}
@@ -230,18 +223,15 @@ func (w *workspaceBuilder) Revoke(ctx context.Context, grant *v2.Grant) (annotat
 		return nil, fmt.Errorf("databricks-connector: only users, groups and service principals can have workspace membership revoked")
 	}
 
-	groupTrait, err := rs.GetGroupTrait(entitlement.Resource)
-	if err != nil {
-		return nil, fmt.Errorf("databricks-connector: failed to get group trait: %w", err)
-	}
+	profile := rs.GetProfile(entitlement.Resource)
 
-	workspaceID, ok := rs.GetProfileInt64Value(groupTrait.Profile, "workspace_id")
+	workspaceID, ok := rs.GetProfileInt64Value(profile, "workspace_id")
 	if !ok {
-		return nil, fmt.Errorf("databricks-connector: failed to get workspace ID: %w", err)
+		return nil, fmt.Errorf("databricks-connector: failed to get workspace ID")
 	}
 
 	workspace := strconv.Itoa(int(workspaceID))
-	_, err = w.client.RemoveWorkspaceMember(ctx, workspace, principal.Id.Resource)
+	_, err := w.client.RemoveWorkspaceMember(ctx, workspace, principal.Id.Resource)
 	if err != nil {
 		return nil, fmt.Errorf("databricks-connector: failed to create or update workspace member: %w", err)
 	}

--- a/pkg/databricks/client.go
+++ b/pkg/databricks/client.go
@@ -14,7 +14,7 @@ import (
 const (
 	defaultHost = "cloud.databricks.com" // aws
 	azureHost   = "azuredatabricks.net"
-	gcpHost     = "gcp.databricks.net"
+	gcpHost     = "gcp.databricks.com"
 
 	// Some of these are case sensitive.
 	usersEndpoint             = "/api/2.0/preview/scim/v2/Users"


### PR DESCRIPTION
Azure and GCP Databricks tenants now connect and sync automatically instead of failing, by calculating the correct account address from the workspace address rather than always defaulting to the AWS one.