### PR TITLE
CXH-2109: graceful 403 handling, workspace exclude flag, doc cleanup

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,28 +17,17 @@ of an account, after you log into account platform and click on your username in
 right top corner that will open a dropdown menu with the account ID along other
 options.
 
-Another requirement is to have valid credentials to run the connector with. This
-will decide how connector will be executed. You can use either OAuth client
-credentials flow or Basic auth flow (username and password) or Bearer auth flow.
-Both OAuth and Basic can be used across account and all workspaces you have
-access to. Bearer auth can be used only for a specific workspace.
+Another requirement is to have valid credentials to run the connector with. The
+connector authenticates with an OAuth service principal using the client
+credentials flow, which works across the account and every workspace the service
+principal has access to.
 
-To use the OAuth, you need to create a service principal and add OAuth secret
-(client id and secret) to it. You can do that by going to the user management
-tab and clicking on the Service Principals tab. Then click on the Add Service
-principal button and name it. You then need to add OAuth secret to it by
-clicking on the Generate secret button. You can use this secret to authenticate
-across all workspaces that service principal has access to. To use basic auth,
-you just need to provide a username and password of a user that has access to
-the Databricks API. Both methods require admin access to the Databricks account
-and each workspace you want to sync.
-
-To use bearer auth, you need to provide a Databricks workspace access token. You
-can create a new token by logging into the workspace and going into user
-settings. Then go to Developer tab and create a new access token. This will try
-to work with only specified workspaces and their respective tokens. You can
-provide multiple tokens by separating them with a comma. This method requires
-admin access to each workspace you want to sync.
+To set this up, create a service principal and add an OAuth secret (client ID
+and secret) to it. Go to the user management tab, click the Service Principals
+tab, click Add Service principal, and name it. Then add an OAuth secret to it by
+clicking Generate secret. Use this client ID and secret to authenticate. The
+service principal needs admin access to the Databricks account and each
+workspace you want to sync.
 
 # Using Azure Databricks
 
@@ -55,14 +44,14 @@ baton-databricks --hostname "azuredatabricks.net"
 ```
 brew install conductorone/baton/baton conductorone/baton/baton-databricks
 
-BATON_ACCOUNT_ID=account_id BATON_USERNAME=username BATON_PASSWORD=password baton-databricks
+BATON_ACCOUNT_ID=account_id BATON_DATABRICKS_CLIENT_ID=client_id BATON_DATABRICKS_CLIENT_SECRET=client_secret baton-databricks
 baton resources
 ```
 
 ## docker
 
 ```
-docker run --rm -v $(pwd):/out -e BATON_ACCOUNT_ID=account_id BATON_USERNAME=username BATON_PASSWORD=password ghcr.io/conductorone/baton-databricks:latest -f "/out/sync.c1z"
+docker run --rm -v $(pwd):/out -e BATON_ACCOUNT_ID=account_id -e BATON_DATABRICKS_CLIENT_ID=client_id -e BATON_DATABRICKS_CLIENT_SECRET=client_secret ghcr.io/conductorone/baton-databricks:latest -f "/out/sync.c1z"
 docker run --rm -v $(pwd):/out ghcr.io/conductorone/baton:latest -f "/out/sync.c1z" resources
 ```
 
@@ -72,7 +61,7 @@ docker run --rm -v $(pwd):/out ghcr.io/conductorone/baton:latest -f "/out/sync.c
 go install github.com/conductorone/baton/cmd/baton@main
 go install github.com/conductorone/baton-databricks/cmd/baton-databricks@main
 
-BATON_ACCOUNT_ID=account_id BATON_USERNAME=username BATON_PASSWORD=password baton-databricks
+BATON_ACCOUNT_ID=account_id BATON_DATABRICKS_CLIENT_ID=client_id BATON_DATABRICKS_CLIENT_SECRET=client_secret baton-databricks
 baton resources
 ```
 
@@ -87,15 +76,12 @@ baton resources
 - Users
 - Roles
 
-By default, connector will fetch all resources from the account and all
-workspaces. You can limit the scope of the sync by providing a list of
-workspaces to sync with. You can do that by providing a comma-separated list of
-workspace hostnames to the `--workspaces` flag. You can also provide a list of
-workspace access tokens to the `--workspace-tokens` flag. This will limit the
-sync to only workspaces that are associated with those tokens. You can also use
-both flags at the same time. If you do that, connector will sync with all
-workspaces that are associated with provided tokens and all workspaces that are
-in the list of workspaces.
+By default, the connector fetches all resources from the account and every
+workspace the service principal can access. To exclude specific workspaces from
+the sync, pass them to the `--databricks-exclude-workspaces` flag (or the
+`BATON_DATABRICKS_EXCLUDE_WORKSPACES` environment variable) as a comma-separated
+list. Each entry can be a workspace name, deployment name, or numeric workspace
+ID. Excluded workspaces and their roles are skipped entirely.
 
 ## Group povisioning limitations
 provisioning of account groups from a workspace token is not supported, if you need to provision groups you can only do it using the client-id and client-secret flow,
@@ -123,24 +109,29 @@ Usage:
 Available Commands:
   capabilities       Get connector capabilities
   completion         Generate the autocompletion script for the specified shell
+  config             Get the connector config schema
+  health-check       Check the health of a running connector
   help               Help about any command
 
 Flags:
-      --account-hostname string           The hostname used to connect to the Databricks account API. If not set, it will be calculated from the hostname field. ($BATON_ACCOUNT_HOSTNAME)
-      --account-id string                 required: The Databricks account ID used to connect to the Databricks Account and Workspace API ($BATON_ACCOUNT_ID)
-      --client-id string                  The client ID used to authenticate with ConductorOne ($BATON_CLIENT_ID)
-      --client-secret string              The client secret used to authenticate with ConductorOne ($BATON_CLIENT_SECRET)
-      --databricks-client-id string       The Databricks service principal's client ID used to connect to the Databricks Account and Workspace API ($BATON_DATABRICKS_CLIENT_ID)
-      --databricks-client-secret string   The Databricks service principal's client secret used to connect to the Databricks Account and Workspace API ($BATON_DATABRICKS_CLIENT_SECRET)
-  -f, --file string                       The path to the c1z file to sync with ($BATON_FILE) (default "sync.c1z")
-  -h, --help                              help for baton-databricks
-      --hostname string                   The Databricks hostname used to connect to the Databricks API ($BATON_HOSTNAME) (default "cloud.databricks.com")
-      --log-format string                 The output format for logs: json, console ($BATON_LOG_FORMAT) (default "json")
-      --log-level string                  The log level: debug, info, warn, error ($BATON_LOG_LEVEL) (default "info")
-  -p, --provisioning                      This must be set in order for provisioning actions to be enabled ($BATON_PROVISIONING)
-      --skip-full-sync                    This must be set to skip a full sync ($BATON_SKIP_FULL_SYNC)
-      --ticketing                         This must be set to enable ticketing support ($BATON_TICKETING)
-  -v, --version                           version for baton-databricks
+      --account-hostname string                          The hostname used to connect to the Databricks account API. If not set, it will be calculated from the hostname field. ($BATON_ACCOUNT_HOSTNAME)
+      --account-id string                                required: The Databricks account ID used to connect to the Databricks Account and Workspace API ($BATON_ACCOUNT_ID)
+      --client-id string                                 The client ID used to authenticate with ConductorOne ($BATON_CLIENT_ID)
+      --client-secret string                             The client secret used to authenticate with ConductorOne ($BATON_CLIENT_SECRET)
+      --databricks-client-id string                      required: The Databricks service principal's client ID used to connect to the Databricks Account and Workspace API ($BATON_DATABRICKS_CLIENT_ID)
+      --databricks-client-secret string                  required: The Databricks service principal's client secret used to connect to the Databricks Account and Workspace API ($BATON_DATABRICKS_CLIENT_SECRET)
+      --databricks-exclude-workspaces strings            Workspaces to exclude from sync, identified by workspace name, deployment name, or numeric workspace ID ($BATON_DATABRICKS_EXCLUDE_WORKSPACES)
+  -f, --file string                                      The path to the c1z file to sync with ($BATON_FILE) (default "sync.c1z")
+      --health-check                                     Enable the HTTP health check endpoint ($BATON_HEALTH_CHECK)
+  -h, --help                                             help for baton-databricks
+      --hostname string                                  The Databricks hostname used to connect to the Databricks API ($BATON_HOSTNAME) (default "cloud.databricks.com")
+      --log-format string                                The output format for logs: json, console ($BATON_LOG_FORMAT) (default "json")
+      --log-level string                                 The log level: debug, info, warn, error ($BATON_LOG_LEVEL) (default "info")
+  -p, --provisioning                                     This must be set in order for provisioning actions to be enabled ($BATON_PROVISIONING)
+      --skip-full-sync                                   This must be set to skip a full sync ($BATON_SKIP_FULL_SYNC)
+      --storage-engine string                            The storage engine to use when opening the sync c1z file: sqlite or pebble. Leave unset to use the baton-sdk default. ($BATON_STORAGE_ENGINE)
+      --ticketing                                        This must be set to enable ticketing support ($BATON_TICKETING)
+  -v, --version                                          version for baton-databricks
 
 Use "baton-databricks [command] --help" for more information about a command.
 ```

--- a/README.md
+++ b/README.md
@@ -116,22 +116,37 @@ Available Commands:
 Flags:
       --account-hostname string                          The hostname used to connect to the Databricks account API. If not set, it will be calculated from the hostname field. ($BATON_ACCOUNT_HOSTNAME)
       --account-id string                                required: The Databricks account ID used to connect to the Databricks Account and Workspace API ($BATON_ACCOUNT_ID)
+      --auth-method string                               ($BATON_AUTH_METHOD)
       --client-id string                                 The client ID used to authenticate with ConductorOne ($BATON_CLIENT_ID)
       --client-secret string                             The client secret used to authenticate with ConductorOne ($BATON_CLIENT_SECRET)
       --databricks-client-id string                      required: The Databricks service principal's client ID used to connect to the Databricks Account and Workspace API ($BATON_DATABRICKS_CLIENT_ID)
       --databricks-client-secret string                  required: The Databricks service principal's client secret used to connect to the Databricks Account and Workspace API ($BATON_DATABRICKS_CLIENT_SECRET)
       --databricks-exclude-workspaces strings            Workspaces to exclude from sync, identified by workspace name, deployment name, or numeric workspace ID ($BATON_DATABRICKS_EXCLUDE_WORKSPACES)
+      --external-resource-c1z string                     The path to the c1z file to sync external baton resources with ($BATON_EXTERNAL_RESOURCE_C1Z)
+      --external-resource-entitlement-id-filter string   The entitlement that external users, groups must have access to sync external baton resources ($BATON_EXTERNAL_RESOURCE_ENTITLEMENT_ID_FILTER)
   -f, --file string                                      The path to the c1z file to sync with ($BATON_FILE) (default "sync.c1z")
       --health-check                                     Enable the HTTP health check endpoint ($BATON_HEALTH_CHECK)
+      --health-check-port int                            Port for the HTTP health check endpoint ($BATON_HEALTH_CHECK_PORT) (default 8081)
   -h, --help                                             help for baton-databricks
       --hostname string                                  The Databricks hostname used to connect to the Databricks API ($BATON_HOSTNAME) (default "cloud.databricks.com")
+      --http-timeout-seconds int                         HTTP client timeout in seconds (max 1800) ($BATON_HTTP_TIMEOUT_SECONDS) (default 300)
+      --keep-previous-sync-c1z                           Keep the previously synced c1z on disk to enable ETag replay across service-mode syncs (requires a connector that supports ETag replay; costs one c1z of local disk) ($BATON_KEEP_PREVIOUS_SYNC_C1Z)
       --log-format string                                The output format for logs: json, console ($BATON_LOG_FORMAT) (default "json")
       --log-level string                                 The log level: debug, info, warn, error ($BATON_LOG_LEVEL) (default "info")
+      --log-level-debug-expires-at string                The timestamp indicating when debug-level logging should expire ($BATON_LOG_LEVEL_DEBUG_EXPIRES_AT)
+      --log-path strings                                 The file path to write logs to ($BATON_LOG_PATH)
+      --otel-collector-endpoint string                   The endpoint of the OpenTelemetry collector to send observability data to (used for both tracing and logging if specific endpoints are not provided) ($BATON_OTEL_COLLECTOR_ENDPOINT)
+      --parallel-sync                                    Deprecated: use --workers instead. ($BATON_PARALLEL_SYNC)
   -p, --provisioning                                     This must be set in order for provisioning actions to be enabled ($BATON_PROVISIONING)
+      --skip-entitlements-and-grants                     This must be set to skip syncing of entitlements and grants ($BATON_SKIP_ENTITLEMENTS_AND_GRANTS)
       --skip-full-sync                                   This must be set to skip a full sync ($BATON_SKIP_FULL_SYNC)
       --storage-engine string                            The storage engine to use when opening the sync c1z file: sqlite or pebble. Leave unset to use the baton-sdk default. ($BATON_STORAGE_ENGINE)
+      --sync-resource-types strings                      The resource type IDs to sync ($BATON_SYNC_RESOURCE_TYPES)
+      --sync-resources strings                           The resource IDs to sync ($BATON_SYNC_RESOURCES)
+      --task-concurrency int                             The number of Baton tasks to run concurrently in service mode. Tasks may include sync, grant, revoke, and more. Minimum value is 1, maximum value is 100. ($BATON_TASK_CONCURRENCY) (default 3)
       --ticketing                                        This must be set to enable ticketing support ($BATON_TICKETING)
   -v, --version                                          version for baton-databricks
+      --workers int                                      The number of sync workers to use. -1 for auto-detect, 0 for sequential, >0 for parallel ($BATON_WORKERS)
 
 Use "baton-databricks [command] --help" for more information about a command.
 ```

--- a/config_schema.json
+++ b/config_schema.json
@@ -139,6 +139,12 @@
       "stringField": {
         "defaultValue": "cloud.databricks.com"
       }
+    },
+    {
+      "name": "databricks-exclude-workspaces",
+      "displayName": "Exclude Workspaces",
+      "description": "Workspaces to exclude from sync, identified by workspace name, deployment name, or numeric workspace ID",
+      "stringSliceField": {}
     }
   ],
   "displayName": "Databricks",

--- a/docs/connector.mdx
+++ b/docs/connector.mdx
@@ -42,54 +42,22 @@ A user with the **Account admin** role in each Databricks workspace you want to 
 
 ### Generate Databricks credentials
 
-You have three authentication choices when setting up the Databricks connector:
+The Databricks connector authenticates with an OAuth service principal, which syncs info from every workspace the service principal can access.
 
-- **OAuth** (syncs info from all Databricks workspaces)
-
-  <Steps>
-    <Step>
-    Follow the [Databricks OAuth authentication documentation](https://docs.databricks.com/en/dev-tools/auth/oauth-m2m.html) to create a service principal and create an OAuth secret.
-    </Step>
-    <Step>
-    Carefully copy and save the OAuth client ID and secret.
-    </Step>
-  </Steps>
-
-- **Personal access token** (syncs info from a single Databricks workspace)
-
-  <Steps>
-    <Step>
-    In Databricks, navigate to **Settings** > **Developer** > **Access tokens** and click **Manage**.
-    </Step>
-    <Step>
-    Click **Generate new token** and create a new token.
-    </Step>
-    <Step>
-    Carefully copy and save the token.
-    </Step>
-  </Steps>
-
-- **Username and password** (syncs info from all Databricks workspaces)
-
-  You do not need to generate any additional credentials to use this method.
+<Steps>
+  <Step>
+  Follow the [Databricks OAuth authentication documentation](https://docs.databricks.com/en/dev-tools/auth/oauth-m2m.html) to create a service principal and create an OAuth secret.
+  </Step>
+  <Step>
+  Carefully copy and save the OAuth client ID and secret.
+  </Step>
+</Steps>
 
 **Done.** Here's the set of credentials you'll need when setting up the connector:
 
 - Account ID
 - OAuth client ID
 - OAuth client secret
-
-OR
-
-- Account ID
-- Personal access token
-- Workspace ID for the Databricks workspace you're syncing
-
-OR
-
-- Account ID
-- Username
-- Password
 
 Next, move on to the instructions for your chosen setup method.
 
@@ -132,13 +100,10 @@ To complete this task, you'll need:
   Find the **Settings** area of the page and click **Edit**.
   </Step>
   <Step>
-  Select whether you're authenticating with **OAuth**, a **Personal access token**, or your **Username and password**.
-  </Step>
-  <Step>
   Paste the account ID you looked up in Step 1 into the **Account ID** field.
   </Step>
   <Step>
-  Enter the required OAuth, token, or username and password credentials into the other two fields.
+  Enter your OAuth client ID and client secret into the corresponding fields.
   </Step>
   <Step>
   **Google Cloud Platform and Azure Databricks customers only:** Enter your Databricks account hostname and hostname in the relevant fields.
@@ -219,20 +184,13 @@ stringData:
   BATON_CLIENT_ID: <C1 client ID>
   BATON_CLIENT_SECRET: <C1 client secret>
   
-  # Databricks credentials, option 1
+  # Databricks credentials
   BATON_ACCOUNT_ID: <Databricks account ID>
   BATON_DATABRICKS_CLIENT_ID: <OAuth client ID>
   BATON_DATABRICKS_CLIENT_SECRET: <OAuth client secret>
 
-  # Databricks credentials, option 2
-  BATON_ACCOUNT_ID: <Databricks account ID>
-  BATON_WORKSPACE_TOKENS: <Personal access token>
-  BATON_WORKSPACES: <Workspace ID for the Databricks workspace you're syncing>
-
-  # Databricks credentials, option 3
-  BATON_ACCOUNT_ID: <Databricks account ID>
-  BATON_USERNAME: <Username for the Databricks account>
-  BATON_PASSWORD: <Password for the Databricks account>
+  # Optional: comma-separated workspaces to exclude from sync (workspace name, deployment name, or numeric ID)
+  BATON_DATABRICKS_EXCLUDE_WORKSPACES: <workspace-a,workspace-b>
 
   # Optional: include if you want C1 to provision access using this connector
   BATON_PROVISIONING: true

--- a/pkg/config/conf.gen.go
+++ b/pkg/config/conf.gen.go
@@ -10,6 +10,7 @@ type Databricks struct {
 	DatabricksClientSecret string `mapstructure:"databricks-client-secret"`
 	Hostname string `mapstructure:"hostname"`
 	BaseUrl string `mapstructure:"base-url"`
+	DatabricksExcludeWorkspaces []string `mapstructure:"databricks-exclude-workspaces"`
 }
 
 func (c *Databricks) findFieldByTag(tagValue string) (any, bool) {

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -41,6 +41,11 @@ var (
 		field.WithHidden(true),
 		field.WithExportTarget(field.ExportTargetCLIOnly),
 	)
+	ExcludeWorkspacesField = field.StringSliceField(
+		"databricks-exclude-workspaces",
+		field.WithDescription("Workspaces to exclude from sync, identified by workspace name, deployment name, or numeric workspace ID"),
+		field.WithDisplayName("Exclude Workspaces"),
+	)
 	configFields = []field.SchemaField{
 		AccountHostnameField,
 		AccountIdField,
@@ -48,6 +53,7 @@ var (
 		DatabricksClientSecretField,
 		HostnameField,
 		BaseURLField,
+		ExcludeWorkspacesField,
 	}
 )
 

--- a/pkg/connector/connector.go
+++ b/pkg/connector/connector.go
@@ -147,13 +147,14 @@ func New(
 	accountID,
 	baseURL string,
 	auth databricks.Auth,
+	excludeWorkspaces []string,
 ) (*Databricks, error) {
 	httpClient, err := auth.GetClient(ctx)
 	if err != nil {
 		return nil, err
 	}
 
-	client, err := databricks.NewClient(ctx, httpClient, hostname, accountHostname, accountID, baseURL, auth)
+	client, err := databricks.NewClient(ctx, httpClient, hostname, accountHostname, accountID, baseURL, auth, excludeWorkspaces)
 	if err != nil {
 		return nil, err
 	}
@@ -177,6 +178,7 @@ func NewConnector(ctx context.Context, cfg *config.Databricks, opts *cli.Connect
 		cfg.AccountId,
 		cfg.BaseUrl,
 		auth,
+		cfg.DatabricksExcludeWorkspaces,
 	)
 	if err != nil {
 		l.Warn("error creating connector", zap.Error(err))

--- a/pkg/connector/roles.go
+++ b/pkg/connector/roles.go
@@ -129,17 +129,16 @@ func (r *roleBuilder) Entitlements(
 	}, nil, nil
 }
 
-// Grants returns all the grants for a given role.
-// Since Databricks API does not support listing grants for a role, so that it aligns with the sdk API,
-// we have to go through all the users, groups and servicePrincipals to check if they have the role.
-// isWorkspaceAccessForbidden reports whether err is a 403 from a workspace-scoped
-// API call. This happens when the service principal has account-level access but is
-// not an admin on that specific workspace; such workspaces are skipped so one
-// inaccessible workspace does not fail the whole sync.
+// A 403 here means the service principal has account access but isn't a
+// workspace admin; such workspaces are skipped rather than failing the whole sync.
 func isWorkspaceAccessForbidden(err error) bool {
 	var apiErr *databricks.APIError
 	return errors.As(err, &apiErr) && apiErr.StatusCode == http.StatusForbidden
 }
+
+// Grants returns all the grants for a given role.
+// Since Databricks API does not support listing grants for a role, so that it aligns with the sdk API,
+// we have to go through all the users, groups and servicePrincipals to check if they have the role.
 
 func (r *roleBuilder) Grants(ctx context.Context, resource *v2.Resource, attr rs.SyncOpAttrs) ([]*v2.Grant, *rs.SyncOpResults, error) {
 	l := ctxzap.Extract(ctx)

--- a/pkg/connector/roles.go
+++ b/pkg/connector/roles.go
@@ -139,7 +139,6 @@ func isWorkspaceAccessForbidden(err error) bool {
 // Grants returns all the grants for a given role.
 // Since Databricks API does not support listing grants for a role, so that it aligns with the sdk API,
 // we have to go through all the users, groups and servicePrincipals to check if they have the role.
-
 func (r *roleBuilder) Grants(ctx context.Context, resource *v2.Resource, attr rs.SyncOpAttrs) ([]*v2.Grant, *rs.SyncOpResults, error) {
 	l := ctxzap.Extract(ctx)
 	var rv []*v2.Grant

--- a/pkg/connector/roles.go
+++ b/pkg/connector/roles.go
@@ -2,7 +2,9 @@ package connector
 
 import (
 	"context"
+	"errors"
 	"fmt"
+	"net/http"
 
 	"github.com/conductorone/baton-databricks/pkg/databricks"
 	v2 "github.com/conductorone/baton-sdk/pb/c1/connector/v2"
@@ -130,7 +132,17 @@ func (r *roleBuilder) Entitlements(
 // Grants returns all the grants for a given role.
 // Since Databricks API does not support listing grants for a role, so that it aligns with the sdk API,
 // we have to go through all the users, groups and servicePrincipals to check if they have the role.
+// isWorkspaceAccessForbidden reports whether err is a 403 from a workspace-scoped
+// API call. This happens when the service principal has account-level access but is
+// not an admin on that specific workspace; such workspaces are skipped so one
+// inaccessible workspace does not fail the whole sync.
+func isWorkspaceAccessForbidden(err error) bool {
+	var apiErr *databricks.APIError
+	return errors.As(err, &apiErr) && apiErr.StatusCode == http.StatusForbidden
+}
+
 func (r *roleBuilder) Grants(ctx context.Context, resource *v2.Resource, attr rs.SyncOpAttrs) ([]*v2.Grant, *rs.SyncOpResults, error) {
+	l := ctxzap.Extract(ctx)
 	var rv []*v2.Grant
 
 	profile := rs.GetProfile(resource)
@@ -179,7 +191,13 @@ func (r *roleBuilder) Grants(ctx context.Context, resource *v2.Resource, attr rs
 			databricks.NewUserRolesAttrVars(),
 		)
 		if err != nil {
-			return nil, nil, fmt.Errorf("databricks-connector: failed to list users: %w", err)
+			if isWorkspaceRole && isWorkspaceAccessForbidden(err) {
+				l.Info("databricks-connector: workspace not accessible to service principal, skipping users",
+					zap.String("workspace_id", workspaceId))
+				users, total = nil, 0
+			} else {
+				return nil, nil, fmt.Errorf("databricks-connector: failed to list users: %w", err)
+			}
 		}
 
 		// check if user has the role
@@ -215,7 +233,13 @@ func (r *roleBuilder) Grants(ctx context.Context, resource *v2.Resource, attr rs
 			databricks.NewGroupRolesAttrVars(),
 		)
 		if err != nil {
-			return nil, nil, fmt.Errorf("databricks-connector: failed to list groups: %w", err)
+			if isWorkspaceRole && isWorkspaceAccessForbidden(err) {
+				l.Info("databricks-connector: workspace not accessible to service principal, skipping groups",
+					zap.String("workspace_id", workspaceId))
+				groups, total = nil, 0
+			} else {
+				return nil, nil, fmt.Errorf("databricks-connector: failed to list groups: %w", err)
+			}
 		}
 
 		// check if group has the role
@@ -254,7 +278,13 @@ func (r *roleBuilder) Grants(ctx context.Context, resource *v2.Resource, attr rs
 			databricks.NewServicePrincipalRolesAttrVars(),
 		)
 		if err != nil {
-			return nil, nil, fmt.Errorf("databricks-connector: failed to list service principals: %w", err)
+			if isWorkspaceRole && isWorkspaceAccessForbidden(err) {
+				l.Info("databricks-connector: workspace not accessible to service principal, skipping service principals",
+					zap.String("workspace_id", workspaceId))
+				servicePrincipals, total = nil, 0
+			} else {
+				return nil, nil, fmt.Errorf("databricks-connector: failed to list service principals: %w", err)
+			}
 		}
 
 		// check if service principal has the role

--- a/pkg/connector/roles_test.go
+++ b/pkg/connector/roles_test.go
@@ -1,0 +1,32 @@
+package connector
+
+import (
+	"fmt"
+	"net/http"
+	"testing"
+
+	"github.com/conductorone/baton-databricks/pkg/databricks"
+)
+
+func TestIsWorkspaceAccessForbidden(t *testing.T) {
+	tests := []struct {
+		name string
+		err  error
+		want bool
+	}{
+		{"403 API error", &databricks.APIError{StatusCode: http.StatusForbidden}, true},
+		{"wrapped 403 API error", fmt.Errorf("list: %w", &databricks.APIError{StatusCode: http.StatusForbidden}), true},
+		{"400 API error", &databricks.APIError{StatusCode: http.StatusBadRequest}, false},
+		{"500 API error", &databricks.APIError{StatusCode: http.StatusInternalServerError}, false},
+		{"non-API error", fmt.Errorf("network timeout"), false},
+		{"nil error", nil, false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := isWorkspaceAccessForbidden(tt.err); got != tt.want {
+				t.Errorf("isWorkspaceAccessForbidden(%v) = %v, want %v", tt.err, got, tt.want)
+			}
+		})
+	}
+}

--- a/pkg/databricks/client.go
+++ b/pkg/databricks/client.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"net/http"
 	"net/url"
+	"strconv"
 	"strings"
 
 	v2 "github.com/conductorone/baton-sdk/pb/c1/connector/v2"
@@ -34,12 +35,13 @@ const (
 )
 
 type Client struct {
-	httpClient     *uhttp.BaseHttpClient
-	baseUrl        *url.URL
-	accountBaseUrl *url.URL
-	auth           Auth
-	etag           string
-	accountId      string
+	httpClient        *uhttp.BaseHttpClient
+	baseUrl           *url.URL
+	accountBaseUrl    *url.URL
+	auth              Auth
+	etag              string
+	accountId         string
+	excludeWorkspaces map[string]struct{}
 
 	isAccAPIAvailable bool
 	isWSAPIAvailable  bool
@@ -54,9 +56,17 @@ func GetAccountHostname(hostname string) string {
 	return "accounts." + hostname
 }
 
-func NewClient(ctx context.Context, httpClient *http.Client, hostname, accountHostname, accountID, baseURL string, auth Auth) (*Client, error) {
+func NewClient(ctx context.Context, httpClient *http.Client, hostname, accountHostname, accountID, baseURL string, auth Auth, excludeWorkspaces []string) (*Client, error) {
 	var baseUrl *url.URL
 	var err error
+
+	excludeSet := make(map[string]struct{}, len(excludeWorkspaces))
+	for _, w := range excludeWorkspaces {
+		if w == "" {
+			continue
+		}
+		excludeSet[w] = struct{}{}
+	}
 
 	// If baseURL is provided, use it directly (for testing)
 	if baseURL != "" {
@@ -78,12 +88,25 @@ func NewClient(ctx context.Context, httpClient *http.Client, hostname, accountHo
 
 	cli, err := uhttp.NewBaseHttpClientWithContext(ctx, httpClient)
 	return &Client{
-		httpClient:     cli,
-		auth:           auth,
-		accountId:      accountID,
-		accountBaseUrl: accountBaseUrl,
-		baseUrl:        baseUrl,
+		httpClient:        cli,
+		auth:              auth,
+		accountId:         accountID,
+		accountBaseUrl:    accountBaseUrl,
+		baseUrl:           baseUrl,
+		excludeWorkspaces: excludeSet,
 	}, err
+}
+
+func (c *Client) isWorkspaceExcluded(w Workspace) bool {
+	if len(c.excludeWorkspaces) == 0 {
+		return false
+	}
+	for _, key := range []string{w.Name, w.DeploymentName, strconv.Itoa(w.ID)} {
+		if _, ok := c.excludeWorkspaces[key]; ok {
+			return true
+		}
+	}
+	return false
 }
 
 func (c *Client) workspaceUrl(workspaceId string) *url.URL {
@@ -514,7 +537,19 @@ func (c *Client) ListWorkspaces(
 		return nil, ratelimitData, err
 	}
 
-	return res, ratelimitData, nil
+	if len(c.excludeWorkspaces) == 0 {
+		return res, ratelimitData, nil
+	}
+
+	filtered := make([]Workspace, 0, len(res))
+	for _, w := range res {
+		if c.isWorkspaceExcluded(w) {
+			continue
+		}
+		filtered = append(filtered, w)
+	}
+
+	return filtered, ratelimitData, nil
 }
 
 func (c *Client) ListWorkspaceMembers(


### PR DESCRIPTION
Databricks customers whose service account can't access every workspace no longer have their entire sync fail; the connector now skips just that workspace and continues. Customers can also exclude specific workspaces from sync.